### PR TITLE
Feat/simple community handles

### DIFF
--- a/backend-public/Clarinet.toml
+++ b/backend-public/Clarinet.toml
@@ -14,12 +14,11 @@ depends_on = []
 path = "contracts/approving-namespace-controller.clar"
 depends_on = []
 
-[contracts.approving-namespace-controller-2]
-path = "contracts/approving-namespace-controller.clar"
+[contracts.preordering-namespace-controller]
+path = "contracts/preordering-namespace-controller.clar"
 depends_on = []
 
-
-[contracts.preordering-namespace-controller]
+[contracts.preordering-namespace-controller-2]
 path = "contracts/preordering-namespace-controller.clar"
 depends_on = []
 

--- a/backend-public/contracts/approving-namespace-controller.clar
+++ b/backend-public/contracts/approving-namespace-controller.clar
@@ -21,8 +21,7 @@
         (asserts! (secp256k1-verify hash approval-signature (var-get approval-pubkey)) err-not-authorized)
         (try! (stx-transfer? u1 tx-sender (as-contract tx-sender)))
         (try! (pay-fees price))
-        (try! (as-contract (contract-call? .community-handles name-register namespace name zonefile-hash)))
-        (try! (as-contract (to-bool-response (contract-call? 'SP000000000000000000002Q6VF78.bns name-transfer namespace name owner (some zonefile-hash)))))
+        (try! (as-contract (contract-call? .community-handles name-register namespace name owner zonefile-hash)))
         (ok true)))
 
 

--- a/backend-public/contracts/approving-namespace-controller.clar
+++ b/backend-public/contracts/approving-namespace-controller.clar
@@ -1,5 +1,4 @@
 (define-constant namespace 0x67676767676767676767)
-(define-constant name-salt 0x00)
 
 (define-data-var contract-owner principal tx-sender)
 (define-data-var community-treasury principal tx-sender)
@@ -7,20 +6,69 @@
 (define-data-var price-in-ustx uint u9999999)
 
 (define-constant err-not-authorized (err u403))
+(define-constant err-not-found (err u404))
+(define-constant err-max-renewal-reached (err u500))
 
-;; register an ordered name
+(define-constant err-name-already-claimed (err u2011))
+(define-constant err-name-claimability-expired (err u2012))
+(define-constant err-preorder-already-exists (err u2016))
+(define-constant err-hash-malformated (err u2017))
+
+(define-constant name-preorder-claimability-ttl u144)
+
+(define-map name-preorders
+  { hashed-salted-fqn: (buff 20), buyer: principal }
+  { created-at: uint, claimed: bool })
+
+(define-map renewal-salts
+    (buff 48) (buff 100))
+
+(define-public (name-preorder (hashed-salted-fqn (buff 20)))
+  (let ((price (var-get price-in-ustx))
+        (former-preorder
+            (map-get? name-preorders { hashed-salted-fqn: hashed-salted-fqn, buyer: tx-sender })))
+    ;; Ensure eventual former pre-order expired
+    (asserts!
+      (if (is-none former-preorder)
+        true
+        (>= block-height (+ name-preorder-claimability-ttl
+                            (unwrap-panic (get created-at former-preorder)))))
+      err-preorder-already-exists)
+    ;; Ensure that the hashed fqn is 20 bytes long
+    (asserts! (is-eq (len hashed-salted-fqn) u20) err-hash-malformated)
+    ;; Ensure that user will be paying
+    (try! (pay-fees price))
+    ;; Register the pre-order
+    (map-set name-preorders
+      { hashed-salted-fqn: hashed-salted-fqn, buyer: tx-sender }
+      { created-at: block-height, claimed: false })
+    (ok (+ block-height name-preorder-claimability-ttl))))
+
+;; reveal an ordered name
 ;; @event: tx-sender sends 1 stx
 ;; @event: community-handles burns 1 stx
 ;; @event: community-handles sends name nft to tx-sender
-(define-public (name-register (name (buff 48))
-                              (approval-signature (buff 65))
-                              (zonefile-hash (buff 20)))
-    (let ((price (var-get price-in-ustx))
-          (owner tx-sender)
-          (hash (sha256 (concat (concat (concat name 0x2e) namespace) name-salt))))
+(define-public (name-reveal (name (buff 48))
+                            (salt (buff 20))
+                            (approval-signature (buff 65))
+                            (zonefile-hash (buff 20)))
+    (let ((owner tx-sender)
+          (hashed-salted-fqn (hash160 (concat (concat (concat name 0x2e) namespace) salt)))
+          (preorder (unwrap!
+            (map-get? name-preorders { hashed-salted-fqn: hashed-salted-fqn, buyer: tx-sender })
+            err-not-found))
+          (hash (sha256 (concat (concat (concat name 0x2e) namespace) salt))))
+        ;; Name must be approved by current approver
         (asserts! (secp256k1-verify hash approval-signature (var-get approval-pubkey)) err-not-authorized)
+        ;; The preorder entry must be unclaimed
+        (asserts!
+            (is-eq (get claimed preorder) false)
+            err-name-already-claimed)
+        ;; Less than 24 hours must have passed since the name was preordered
+        (asserts!
+            (< block-height (+ (get created-at preorder) name-preorder-claimability-ttl))
+            err-name-claimability-expired)
         (try! (stx-transfer? u1 tx-sender (as-contract tx-sender)))
-        (try! (pay-fees price))
         (try! (as-contract (contract-call? .community-handles name-register namespace name owner zonefile-hash)))
         (ok true)))
 
@@ -35,8 +83,11 @@
                               (zonefile-hash (optional (buff 20))))
     (let ((price (var-get price-in-ustx))
           (owner tx-sender)
-          (hash (sha256 (concat (concat (concat name 0x2e) namespace) name-salt))))
+          (last-salt (unwrap! (map-get? renewal-salts name) err-not-found))
+          (salt (unwrap! (as-max-len? (concat last-salt 0x00) u100) err-max-renewal-reached))
+          (hash (sha256 (concat (concat (concat name 0x2e) namespace) salt))))
         (asserts! (secp256k1-verify hash approval-signature (var-get approval-pubkey)) err-not-authorized)
+        (map-set renewal-salts name salt)
         (try! (pay-fees price))
         (try! (contract-call? .community-handles name-renewal namespace name u1 new-owner zonefile-hash))
         (ok true)))

--- a/backend-public/contracts/community-handles.clar
+++ b/backend-public/contracts/community-handles.clar
@@ -67,30 +67,6 @@
         (try! (as-contract (to-bool-response (contract-call? 'SP000000000000000000002Q6VF78.bns namespace-update-function-price namespace internal-price-high u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1))))
         (ok true)))
 
-
-;; iterator for bulk-name-register
-(define-private (bulk-name-register-iter (entry {name: (buff 48), owner: principal, zonefile-hash: (buff 20)}) (prev (response bool uint)))
-    (let ((namespace (var-get ctx-bulk-registration-namespace))
-          (name (get name entry))
-          (hash (hash160 (concat (concat (concat name 0x2e) namespace) name-salt))))
-        (try! prev)
-        (try! (to-uint-response (contract-call? 'SP000000000000000000002Q6VF78.bns name-preorder hash u1)))
-        (try! (to-bool-response (contract-call? 'SP000000000000000000002Q6VF78.bns name-register namespace name name-salt (get zonefile-hash entry))))
-        (ok true)))
-
-;; @desc register multiple namens for 1 ustx by namespace controller only
-;; @param namespace; controlled namespace
-;; @param names; list of names with owner and hash of the attachment/zonefile for the name
-(define-public (bulk-name-register (namespace (buff 20)) (names (list 1000 {name: (buff 48), owner: principal, zonefile-hash: (buff 20)})))
-    (begin
-        (try! (is-contract-caller-namespace-controller namespace))
-        (var-set ctx-bulk-registration-namespace namespace)
-        (try! (as-contract (to-bool-response (contract-call? 'SP000000000000000000002Q6VF78.bns namespace-update-function-price namespace u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u1 u1))))
-        (try! (fold bulk-name-register-iter names (ok true)))
-        (var-set ctx-bulk-registration-namespace 0x00)
-        (try! (as-contract (to-bool-response (contract-call? 'SP000000000000000000002Q6VF78.bns namespace-update-function-price namespace internal-price-high u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1))))
-        (ok true)))
-
 ;; convert response to standard uint response with uint error
 ;; (response uint int) (response uint uint)
 (define-private (to-uint-response (value (response uint int)))

--- a/backend-public/contracts/community-handles.clar
+++ b/backend-public/contracts/community-handles.clar
@@ -38,6 +38,16 @@
                                 namespace-ready namespace)))
         (ok true)))
 
+(define-public (namespace-revoke-function-price-edition (namespace (buff 20)))
+    (begin
+        (try! (is-contract-caller-namespace-controller namespace))
+        (try! (ft-mint? danger-zone-token u1 tx-sender))
+        (try! (ft-burn? danger-zone-token u1 tx-sender))
+        (try! (as-contract (to-bool-response (contract-call? 'SP000000000000000000002Q6VF78.bns
+                                namespace-revoke-function-price-edition namespace))))
+        (ok true)))
+
+
 ;; @desc register name for 1 ustx by namespace controller only
 ;; @param namespace; controlled namespace
 ;; @param name; name in the controlled namespace

--- a/backend-public/contracts/community-handles.clar
+++ b/backend-public/contracts/community-handles.clar
@@ -45,12 +45,14 @@
 ;; @param owner; principal owning the name after registration 
 (define-public (name-register (namespace (buff 20))
                               (name (buff 48))
+                              (owner principal)
                               (zonefile-hash (buff 20)))
     (let ((hash (hash160 (concat (concat (concat name 0x2e) namespace) name-salt))))
         (try! (is-contract-caller-namespace-controller namespace))
         (try! (to-uint-response (contract-call? 'SP000000000000000000002Q6VF78.bns name-preorder hash u1)))
         (try! (as-contract (to-bool-response (contract-call? 'SP000000000000000000002Q6VF78.bns namespace-update-function-price namespace u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u1 u1))))
         (try! (to-bool-response (contract-call? 'SP000000000000000000002Q6VF78.bns name-register namespace name name-salt zonefile-hash)))
+        (try! (to-bool-response (contract-call? 'SP000000000000000000002Q6VF78.bns name-transfer namespace name owner (some zonefile-hash))))
         (try! (as-contract (to-bool-response (contract-call? 'SP000000000000000000002Q6VF78.bns namespace-update-function-price namespace internal-price-high u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1))))        
         (ok true)))
 
@@ -64,6 +66,31 @@
         (try! (is-contract-caller-namespace-controller namespace))
         (try! (as-contract (to-bool-response (contract-call? 'SP000000000000000000002Q6VF78.bns namespace-update-function-price namespace u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u1 u1))))
         (try! (to-bool-response (contract-call? 'SP000000000000000000002Q6VF78.bns name-renewal namespace name stx-to-burn new-owner zonefile-hash)))
+        (try! (as-contract (to-bool-response (contract-call? 'SP000000000000000000002Q6VF78.bns namespace-update-function-price namespace internal-price-high u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1))))
+        (ok true)))
+
+
+;; iterator for bulk-name-register
+(define-private (bulk-name-register-iter (entry {name: (buff 48), owner: principal, zonefile-hash: (buff 20)}) (prev (response bool uint)))
+    (let ((namespace (var-get ctx-bulk-registration-namespace))
+          (name (get name entry))
+          (hash (hash160 (concat (concat (concat name 0x2e) namespace) name-salt))))
+        (try! prev)
+        (try! (to-uint-response (contract-call? 'SP000000000000000000002Q6VF78.bns name-preorder hash u1)))
+        (try! (to-bool-response (contract-call? 'SP000000000000000000002Q6VF78.bns name-register namespace name name-salt (get zonefile-hash entry))))
+        (try! (to-bool-response (contract-call? 'SP000000000000000000002Q6VF78.bns name-transfer namespace name (get owner entry) (some (get zonefile-hash entry)))))
+        (ok true)))
+
+;; @desc register multiple namens for 1 ustx by namespace controller only
+;; @param namespace; controlled namespace
+;; @param names; list of names with owner and hash of the attachment/zonefile for the name
+(define-public (bulk-name-register (namespace (buff 20)) (names (list 1000 {name: (buff 48), owner: principal, zonefile-hash: (buff 20)})))
+    (begin
+        (try! (is-contract-caller-namespace-controller namespace))
+        (var-set ctx-bulk-registration-namespace namespace)
+        (try! (as-contract (to-bool-response (contract-call? 'SP000000000000000000002Q6VF78.bns namespace-update-function-price namespace u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u0 u1 u1))))
+        (try! (fold bulk-name-register-iter names (ok true)))
+        (var-set ctx-bulk-registration-namespace 0x00)
         (try! (as-contract (to-bool-response (contract-call? 'SP000000000000000000002Q6VF78.bns namespace-update-function-price namespace internal-price-high u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1 u1))))
         (ok true)))
 

--- a/backend-public/contracts/community-handles.clar
+++ b/backend-public/contracts/community-handles.clar
@@ -38,16 +38,6 @@
                                 namespace-ready namespace)))
         (ok true)))
 
-(define-public (namespace-revoke-function-price-edition (namespace (buff 20)))
-    (begin
-        (try! (is-contract-caller-namespace-controller namespace))
-        (try! (ft-mint? danger-zone-token u1 tx-sender))
-        (try! (ft-burn? danger-zone-token u1 tx-sender))
-        (try! (as-contract (to-bool-response (contract-call? 'SP000000000000000000002Q6VF78.bns
-                                namespace-revoke-function-price-edition namespace))))
-        (ok true)))
-
-
 ;; @desc register name for 1 ustx by namespace controller only
 ;; @param namespace; controlled namespace
 ;; @param name; name in the controlled namespace

--- a/backend-public/contracts/preordering-namespace-controller.clar
+++ b/backend-public/contracts/preordering-namespace-controller.clar
@@ -22,7 +22,8 @@
         (asserts! (is-eq owner tx-sender) err-not-authorized)
         (try! (pay-fees price))
         (try! (stx-transfer? u1 tx-sender (as-contract tx-sender)))
-        (try! (as-contract (contract-call? .community-handles name-register namespace name zonefile-hash owner)))
+        (try! (as-contract (contract-call? .community-handles name-register namespace name zonefile-hash)))
+        (try! (as-contract (to-bool-response (contract-call? 'SP000000000000000000002Q6VF78.bns name-transfer namespace name owner (some zonefile-hash)))))
         (ok true)))
 
 (define-private (pay-fees (price uint))

--- a/backend-public/contracts/preordering-namespace-controller.clar
+++ b/backend-public/contracts/preordering-namespace-controller.clar
@@ -22,8 +22,7 @@
         (asserts! (is-eq owner tx-sender) err-not-authorized)
         (try! (pay-fees price))
         (try! (stx-transfer? u1 tx-sender (as-contract tx-sender)))
-        (try! (as-contract (contract-call? .community-handles name-register namespace name zonefile-hash)))
-        (try! (as-contract (to-bool-response (contract-call? 'SP000000000000000000002Q6VF78.bns name-transfer namespace name owner (some zonefile-hash)))))
+        (try! (as-contract (contract-call? .community-handles name-register namespace name owner zonefile-hash)))
         (ok true)))
 
 (define-private (pay-fees (price uint))

--- a/backend-public/tests/approving-namespace-owner_test.ts
+++ b/backend-public/tests/approving-namespace-owner_test.ts
@@ -24,6 +24,20 @@ Clarinet.test({
 
     block.receipts[0].result.expectOk().expectBool(true);
 
+    const hashResponse1 = chain.callReadOnlyFn(
+      "crypto",
+      "crypto-hash160",
+      ["0x31312e6767676767676767676700"],
+      deployer
+    );
+
+    const hashResponse2 = chain.callReadOnlyFn(
+      "crypto",
+      "crypto-hash160",
+      ["0x32322e6767676767676767676700"],
+      deployer
+    );
+
     block = chain.mineBlock([
       Tx.contractCall(
         "approving-namespace-controller",
@@ -35,9 +49,16 @@ Clarinet.test({
       ),
       Tx.contractCall(
         "approving-namespace-controller",
-        "name-register",
+        "name-preorder",
+        [hashResponse1.result],
+        account1
+      ),
+      Tx.contractCall(
+        "approving-namespace-controller",
+        "name-reveal",
         [
           "0x3131",
+          "0x00",
           "0xd693e8d1d558a5aabff258de2bd5ec6da5eea52ec9b45e4c2c9f34aa547cabb3235ad7223adf3a8d4e51f3cd7fbefdc001fcee9d3e8ddda4643c42dcea07bb6700",
           "0x01020304",
         ],
@@ -45,9 +66,16 @@ Clarinet.test({
       ),
       Tx.contractCall(
         "approving-namespace-controller",
-        "name-register",
+        "name-preorder",
+        [hashResponse2.result],
+        account2
+      ),
+      Tx.contractCall(
+        "approving-namespace-controller",
+        "name-reveal",
         [
           "0x3232",
+          "0x00",
           "0xb045f07cc9ebcba2cefce1191271d2a740a2f8e58987edf80a7813c51797ab8c085be7ccd4c45bda051179a2037dce166d20ca58ada462dad08eeb45427e74c301",
           "0x01020304",
         ],
@@ -56,7 +84,11 @@ Clarinet.test({
     ]);
 
     block.receipts[0].result.expectOk().expectBool(true);
-    block.receipts[1].result.expectOk().expectBool(true);
+    // register a name
+    block.receipts[1].result.expectOk().expectUint(147);
     block.receipts[2].result.expectOk().expectBool(true);
+    // register second name
+    block.receipts[3].result.expectOk().expectUint(147);
+    block.receipts[4].result.expectOk().expectBool(true);
   },
 });

--- a/backend-public/tests/approving-namespace-owner_test.ts
+++ b/backend-public/tests/approving-namespace-owner_test.ts
@@ -14,7 +14,10 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "set-namespace-controller",
-        ["0x67676767676767676767", `'${deployer}.approving-namespace-controller`],
+        [
+          "0x67676767676767676767",
+          `'${deployer}.approving-namespace-controller`,
+        ],
         deployer
       ),
     ]);

--- a/backend-public/tests/community-handles_flows_test.ts
+++ b/backend-public/tests/community-handles_flows_test.ts
@@ -17,58 +17,63 @@ Clarinet.test({
         "set-namespace-controller",
         [
           "0x67676767676767676767",
-          `'${deployer}.approving-namespace-controller`,
+          `'${deployer}.preordering-namespace-controller`,
         ],
         deployer
       ),
       Tx.contractCall(
-        "approving-namespace-controller",
-        "set-approval-pubkey",
+        "preordering-namespace-controller",
+        "bulk-order",
         [
-          "0x02a3b986401a619013ee1deee0ccba58a5b2235260d55259106e5fc9c53e6a9d71",
+          types.list([
+            types.tuple({
+              owner: types.principal(account1),
+              name: "0x3131",
+              price: types.uint(2),
+            }),
+          ]),
         ],
         deployer
       ),
       Tx.contractCall(
-        "approving-namespace-controller",
+        "preordering-namespace-controller",
         "name-register",
-        [
-          "0x3131",
-          "0xd693e8d1d558a5aabff258de2bd5ec6da5eea52ec9b45e4c2c9f34aa547cabb3235ad7223adf3a8d4e51f3cd7fbefdc001fcee9d3e8ddda4643c42dcea07bb6700",
-          "0x01020304",
-        ],
+        ["0x3131", "0x01020304"],
         account1
       ),
       Tx.contractCall(
-        "approving-namespace-controller",
+        "preordering-namespace-controller",
         "set-namespace-controller",
-        [`'${deployer}.approving-namespace-controller-2`],
+        [`'${deployer}.preordering-namespace-controller-2`],
         deployer
       ),
       Tx.contractCall(
-        "approving-namespace-controller-2",
-        "set-approval-pubkey",
+        "preordering-namespace-controller-2",
+        "bulk-order",
         [
-          "0x02a3b986401a619013ee1deee0ccba58a5b2235260d55259106e5fc9c53e6a9d71",
+          types.list([
+            types.tuple({
+              owner: types.principal(account2),
+              name: "0x3232",
+              price: types.uint(9999999),
+            }),
+          ]),
         ],
         deployer
       ),
       Tx.contractCall(
-        "approving-namespace-controller-2",
+        "preordering-namespace-controller-2",
         "name-register",
-        [
-          "0x3232",
-          "0xb045f07cc9ebcba2cefce1191271d2a740a2f8e58987edf80a7813c51797ab8c085be7ccd4c45bda051179a2037dce166d20ca58ada462dad08eeb45427e74c301",
-          "0x01020304",
-        ],
+        ["0x3232", "0x01020304"],
         account2
       ),
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
-    block.receipts[1].result.expectOk().expectBool(true);
+    block.receipts[1].result.expectOk().expectList()[0].expectBool(true);
     block.receipts[2].result.expectOk().expectBool(true);
+    // change controller
     block.receipts[3].result.expectOk().expectBool(true);
-    block.receipts[4].result.expectOk().expectBool(true);
+    block.receipts[4].result.expectOk().expectList()[0].expectBool(true);
     block.receipts[5].result.expectOk().expectBool(true);
   },
 });
@@ -81,6 +86,13 @@ Clarinet.test({
     const account2 = accounts.get("wallet_2")!.address;
 
     setupNamespace(chain, deployer);
+
+    const hashResponse1 = chain.callReadOnlyFn(
+      "crypto",
+      "crypto-hash160",
+      ["0x31312e6767676767676767676700"],
+      deployer
+    );
 
     // setup controller
     let block = chain.mineBlock([
@@ -103,9 +115,16 @@ Clarinet.test({
       ),
       Tx.contractCall(
         "approving-namespace-controller",
-        "name-register",
+        "name-preorder",
+        [hashResponse1.result],
+        account1
+      ),
+      Tx.contractCall(
+        "approving-namespace-controller",
+        "name-reveal",
         [
           "0x3131",
+          "0x00",
           "0xd693e8d1d558a5aabff258de2bd5ec6da5eea52ec9b45e4c2c9f34aa547cabb3235ad7223adf3a8d4e51f3cd7fbefdc001fcee9d3e8ddda4643c42dcea07bb6700",
           "0x01020304",
         ],
@@ -125,7 +144,7 @@ Clarinet.test({
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
     block.receipts[1].result.expectOk().expectBool(true);
-    block.receipts[2].result.expectOk().expectBool(true);
+    block.receipts[2].result.expectOk().expectUint(146);
     block.receipts[3].result.expectOk().expectBool(true);
     console.log(block.receipts[3].events);
   },

--- a/backend-public/tests/community-handles_flows_test.ts
+++ b/backend-public/tests/community-handles_flows_test.ts
@@ -135,6 +135,7 @@ Clarinet.test({
         "name-renewal",
         [
           "0x3131",
+          "0x00",
           "0xd693e8d1d558a5aabff258de2bd5ec6da5eea52ec9b45e4c2c9f34aa547cabb3235ad7223adf3a8d4e51f3cd7fbefdc001fcee9d3e8ddda4643c42dcea07bb6700",
           types.none(),
           types.some("0x01020304"),

--- a/backend-public/tests/community-handles_names_test.ts
+++ b/backend-public/tests/community-handles_names_test.ts
@@ -13,23 +13,16 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "name-register",
-        ["0x67676767676767676767", "0x6767", "0x0102030405060708090a"],
-        deployer
-      ),
-      Tx.contractCall(
-        "SP000000000000000000002Q6VF78.bns",
-        "name-transfer",
         [
           "0x67676767676767676767",
           "0x6767",
           types.principal(account1),
-          types.some("0x0102030405060708090a"),
+          "0x0102030405060708090a",
         ],
         deployer
       ),
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
-    block.receipts[1].result.expectOk().expectBool(true);
 
     // check name owner
     const ownerResponse = chain.callReadOnlyFn(
@@ -68,20 +61,15 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "name-register",
-        ["0x67676767676767676767", "0x6767", "0x0102030405060708090a"],
-        deployer
-      ),
-      Tx.contractCall(
-        "SP000000000000000000002Q6VF78.bns",
-        "name-transfer",
         [
           "0x67676767676767676767",
           "0x6767",
           types.principal(account1),
-          types.some("0x0102030405060708090a"),
+          "0x0102030405060708090a",
         ],
         deployer
       ),
+
       Tx.contractCall(
         "community-handles",
         "name-renewal",
@@ -96,8 +84,7 @@ Clarinet.test({
       ),
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
-    block.receipts[1].result.expectOk().expectBool(true);
-    block.receipts[2].result.expectErr().expectUint(2006); // not authorized operation
+    block.receipts[1].result.expectErr().expectUint(2006); // not authorized operation
   },
 });
 
@@ -113,20 +100,15 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "name-register",
-        ["0x67676767676767676767", "0x6767", "0x0102030405060708090a"],
-        deployer
-      ),
-      Tx.contractCall(
-        "SP000000000000000000002Q6VF78.bns",
-        "name-transfer",
         [
           "0x67676767676767676767",
           "0x6767",
           types.principal(account1),
-          types.some("0x0102030405060708090a"),
+          "0x0102030405060708090a",
         ],
         deployer
       ),
+
       Tx.contractCall(
         "community-handles",
         "name-renewal",
@@ -141,8 +123,7 @@ Clarinet.test({
       ),
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
-    block.receipts[1].result.expectOk().expectBool(true);
-    block.receipts[2].result.expectErr().expectUint(403); // not authorized operation
+    block.receipts[1].result.expectErr().expectUint(403); // not authorized operation
   },
 });
 
@@ -159,23 +140,16 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "name-register",
-        ["0x67676767676767676767", "0x6767", "0x0102030405060708090a"],
-        deployer
-      ),
-      Tx.contractCall(
-        "SP000000000000000000002Q6VF78.bns",
-        "name-transfer",
         [
           "0x67676767676767676767",
           "0x6767",
           types.principal(account1),
-          types.some("0x0102030405060708090a"),
+          "0x0102030405060708090a",
         ],
         deployer
       ),
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
-    block.receipts[1].result.expectOk().expectBool(true);
 
     chain.mineEmptyBlock(999);
 
@@ -183,7 +157,12 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "name-register",
-        ["0x67676767676767676767", "0x6767", "0x0102030405060708090a"],
+        [
+          "0x67676767676767676767",
+          "0x6767",
+          types.principal(account2),
+          "0x0102030405060708090a",
+        ],
         deployer
       ),
     ]);
@@ -193,7 +172,12 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "name-register",
-        ["0x67676767676767676767", "0x6767", "0x0102030405060708090a"],
+        [
+          "0x67676767676767676767",
+          "0x6767",
+          types.principal(account2),
+          "0x0102030405060708090a",
+        ],
         deployer
       ),
     ]);
@@ -213,20 +197,15 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "name-register",
-        ["0x67676767676767676767", "0x6767", "0x0102030405060708090a"],
-        deployer
-      ),
-      Tx.contractCall(
-        "SP000000000000000000002Q6VF78.bns",
-        "name-transfer",
         [
           "0x67676767676767676767",
           "0x6767",
           types.principal(account1),
-          types.some("0x0102030405060708090a"),
+          "0x0102030405060708090a",
         ],
         deployer
       ),
+
       Tx.contractCall(
         "SP000000000000000000002Q6VF78.bns",
         "name-renewal",
@@ -242,7 +221,6 @@ Clarinet.test({
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
     block.receipts[1].result.expectOk().expectBool(true);
-    block.receipts[2].result.expectOk().expectBool(true);
   },
 });
 
@@ -259,20 +237,10 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "name-register",
-        ["0x67676767676767676767", "0x6767", "0x0102030405060708090a"],
+        ["0x67676767676767676767", "0x6767", types.principal(account1),"0x0102030405060708090a"],
         deployer
       ),
-      Tx.contractCall(
-        "SP000000000000000000002Q6VF78.bns",
-        "name-transfer",
-        [
-          "0x67676767676767676767",
-          "0x6767",
-          types.principal(account1),
-          types.some("0x0102030405060708090a"),
-        ],
-        deployer
-      ),
+     
       Tx.contractCall(
         "SP000000000000000000002Q6VF78.bns",
         "name-transfer",
@@ -287,7 +255,6 @@ Clarinet.test({
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
     block.receipts[1].result.expectOk().expectBool(true);
-    block.receipts[2].result.expectOk().expectBool(true);
   },
 });
 
@@ -303,18 +270,7 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "name-register",
-        ["0x67676767676767676767", "0x6767", "0x0102030405060708090a"],
-        deployer
-      ),
-      Tx.contractCall(
-        "SP000000000000000000002Q6VF78.bns",
-        "name-transfer",
-        [
-          "0x67676767676767676767",
-          "0x6767",
-          types.principal(account1),
-          types.some("0x0102030405060708090a"),
-        ],
+        ["0x67676767676767676767", "0x6767", types.principal(account1), "0x0102030405060708090a"],
         deployer
       ),
       Tx.contractCall(
@@ -326,7 +282,6 @@ Clarinet.test({
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
     block.receipts[1].result.expectOk().expectBool(true);
-    block.receipts[2].result.expectOk().expectBool(true);
   },
 });
 
@@ -342,20 +297,10 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "name-register",
-        ["0x67676767676767676767", "0x6767", "0x0102030405060708090a"],
+        ["0x67676767676767676767", "0x6767", types.principal(account1),"0x0102030405060708090a"],
         deployer
       ),
-      Tx.contractCall(
-        "SP000000000000000000002Q6VF78.bns",
-        "name-transfer",
-        [
-          "0x67676767676767676767",
-          "0x6767",
-          types.principal(account1),
-          types.some("0x0102030405060708090a"),
-        ],
-        deployer
-      ),
+     
       Tx.contractCall(
         "SP000000000000000000002Q6VF78.bns",
         "name-revoke",
@@ -365,7 +310,51 @@ Clarinet.test({
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
     block.receipts[1].result.expectOk().expectBool(true);
-    block.receipts[2].result.expectOk().expectBool(true);
+  },
+});
+
+Clarinet.test({
+  name: "Ensure that controller can register names in bulk cheaply and bns price is still high",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    const deployer = accounts.get("deployer")!.address;
+    const account1 = accounts.get("wallet_1")!.address;
+    const account2 = accounts.get("wallet_2")!.address;
+
+    setupNamespace(chain, deployer);
+
+    let block = chain.mineBlock([
+      Tx.contractCall(
+        "community-handles",
+        "bulk-name-register",
+        [
+          "0x67676767676767676767",
+          types.list([
+            types.tuple({
+              name: "0x6767",
+              "zonefile-hash": "0x0102030405060708090a",
+              owner: types.principal(account1),
+            }),
+            types.tuple({
+              name: "0x6868",
+              "zonefile-hash": "0x0102030405060708090b",
+              owner: types.principal(account2),
+            }),
+          ]),
+        ],
+        deployer
+      ),
+    ]);
+    block.receipts[0].result.expectOk().expectBool(true);
+
+    const priceResponse = chain.callReadOnlyFn(
+      "SP000000000000000000002Q6VF78.bns",
+      "get-name-price",
+      ["0x67676767676767676767", "0x6767"],
+      account1
+    );
+    priceResponse.result
+      .expectOk()
+      .expectUint(9999999999999999999999999999990n);
   },
 });
 

--- a/backend-public/tests/community-handles_names_test.ts
+++ b/backend-public/tests/community-handles_names_test.ts
@@ -2,39 +2,48 @@ import { Clarinet, Tx, Chain, Account, types, assertEquals } from "./deps.ts";
 import { setupNamespace } from "./utils.ts";
 
 Clarinet.test({
-  name: "Ensure that deployer can register name cheaply and bns price is still high",
+  name: "Ensure that controller can register name cheaply and bns price is still high",
   async fn(chain: Chain, accounts: Map<string, Account>) {
     const deployer = accounts.get("deployer")!.address;
     const account1 = accounts.get("wallet_1")!.address;
-
+    const anyAccount = accounts.get("wallet_2")!.address;
     setupNamespace(chain, deployer);
 
     let block = chain.mineBlock([
       Tx.contractCall(
         "community-handles",
         "name-register",
+        ["0x67676767676767676767", "0x6767", "0x0102030405060708090a"],
+        deployer
+      ),
+      Tx.contractCall(
+        "SP000000000000000000002Q6VF78.bns",
+        "name-transfer",
         [
           "0x67676767676767676767",
           "0x6767",
-          "0x0102030405060708090a",
           types.principal(account1),
+          types.some("0x0102030405060708090a"),
         ],
         deployer
       ),
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
+    block.receipts[1].result.expectOk().expectBool(true);
 
+    // check name owner
     const ownerResponse = chain.callReadOnlyFn(
       "SP000000000000000000002Q6VF78.bns",
       "name-resolve",
       ["0x67676767676767676767", "0x6767"],
-      account1
+      anyAccount
     );
     ownerResponse.result
       .expectOk()
       .expectTuple()
       ["owner"].expectPrincipal(account1);
 
+    // check bns price
     const priceResponse = chain.callReadOnlyFn(
       "SP000000000000000000002Q6VF78.bns",
       "get-name-price",
@@ -59,11 +68,17 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "name-register",
+        ["0x67676767676767676767", "0x6767", "0x0102030405060708090a"],
+        deployer
+      ),
+      Tx.contractCall(
+        "SP000000000000000000002Q6VF78.bns",
+        "name-transfer",
         [
           "0x67676767676767676767",
           "0x6767",
-          "0x0102030405060708090a",
           types.principal(account1),
+          types.some("0x0102030405060708090a"),
         ],
         deployer
       ),
@@ -81,7 +96,8 @@ Clarinet.test({
       ),
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
-    block.receipts[1].result.expectErr().expectUint(2006); // not authorized operation
+    block.receipts[1].result.expectOk().expectBool(true);
+    block.receipts[2].result.expectErr().expectUint(2006); // not authorized operation
   },
 });
 
@@ -97,11 +113,17 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "name-register",
+        ["0x67676767676767676767", "0x6767", "0x0102030405060708090a"],
+        deployer
+      ),
+      Tx.contractCall(
+        "SP000000000000000000002Q6VF78.bns",
+        "name-transfer",
         [
           "0x67676767676767676767",
           "0x6767",
-          "0x0102030405060708090a",
           types.principal(account1),
+          types.some("0x0102030405060708090a"),
         ],
         deployer
       ),
@@ -119,7 +141,8 @@ Clarinet.test({
       ),
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
-    block.receipts[1].result.expectErr().expectUint(403); // not authorized operation
+    block.receipts[1].result.expectOk().expectBool(true);
+    block.receipts[2].result.expectErr().expectUint(403); // not authorized operation
   },
 });
 
@@ -136,16 +159,23 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "name-register",
+        ["0x67676767676767676767", "0x6767", "0x0102030405060708090a"],
+        deployer
+      ),
+      Tx.contractCall(
+        "SP000000000000000000002Q6VF78.bns",
+        "name-transfer",
         [
           "0x67676767676767676767",
           "0x6767",
-          "0x0102030405060708090a",
           types.principal(account1),
+          types.some("0x0102030405060708090a"),
         ],
         deployer
       ),
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
+    block.receipts[1].result.expectOk().expectBool(true);
 
     chain.mineEmptyBlock(999);
 
@@ -153,12 +183,7 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "name-register",
-        [
-          "0x67676767676767676767",
-          "0x6767",
-          "0x0102030405060708090a",
-          types.principal(account2),
-        ],
+        ["0x67676767676767676767", "0x6767", "0x0102030405060708090a"],
         deployer
       ),
     ]);
@@ -168,17 +193,11 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "name-register",
-        [
-          "0x67676767676767676767",
-          "0x6767",
-          "0x0102030405060708090a",
-          types.principal(account2),
-        ],
+        ["0x67676767676767676767", "0x6767", "0x0102030405060708090a"],
         deployer
       ),
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
-
   },
 });
 
@@ -194,11 +213,17 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "name-register",
+        ["0x67676767676767676767", "0x6767", "0x0102030405060708090a"],
+        deployer
+      ),
+      Tx.contractCall(
+        "SP000000000000000000002Q6VF78.bns",
+        "name-transfer",
         [
           "0x67676767676767676767",
           "0x6767",
-          "0x0102030405060708090a",
           types.principal(account1),
+          types.some("0x0102030405060708090a"),
         ],
         deployer
       ),
@@ -217,6 +242,7 @@ Clarinet.test({
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
     block.receipts[1].result.expectOk().expectBool(true);
+    block.receipts[2].result.expectOk().expectBool(true);
   },
 });
 
@@ -233,11 +259,17 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "name-register",
+        ["0x67676767676767676767", "0x6767", "0x0102030405060708090a"],
+        deployer
+      ),
+      Tx.contractCall(
+        "SP000000000000000000002Q6VF78.bns",
+        "name-transfer",
         [
           "0x67676767676767676767",
           "0x6767",
-          "0x0102030405060708090a",
           types.principal(account1),
+          types.some("0x0102030405060708090a"),
         ],
         deployer
       ),
@@ -255,6 +287,7 @@ Clarinet.test({
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
     block.receipts[1].result.expectOk().expectBool(true);
+    block.receipts[2].result.expectOk().expectBool(true);
   },
 });
 
@@ -270,11 +303,17 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "name-register",
+        ["0x67676767676767676767", "0x6767", "0x0102030405060708090a"],
+        deployer
+      ),
+      Tx.contractCall(
+        "SP000000000000000000002Q6VF78.bns",
+        "name-transfer",
         [
           "0x67676767676767676767",
           "0x6767",
-          "0x0102030405060708090a",
           types.principal(account1),
+          types.some("0x0102030405060708090a"),
         ],
         deployer
       ),
@@ -287,6 +326,7 @@ Clarinet.test({
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
     block.receipts[1].result.expectOk().expectBool(true);
+    block.receipts[2].result.expectOk().expectBool(true);
   },
 });
 
@@ -302,11 +342,17 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "name-register",
+        ["0x67676767676767676767", "0x6767", "0x0102030405060708090a"],
+        deployer
+      ),
+      Tx.contractCall(
+        "SP000000000000000000002Q6VF78.bns",
+        "name-transfer",
         [
           "0x67676767676767676767",
           "0x6767",
-          "0x0102030405060708090a",
           types.principal(account1),
+          types.some("0x0102030405060708090a"),
         ],
         deployer
       ),
@@ -319,11 +365,12 @@ Clarinet.test({
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
     block.receipts[1].result.expectOk().expectBool(true);
+    block.receipts[2].result.expectOk().expectBool(true);
   },
 });
 
 Clarinet.test({
-  name: "Ensure that deployer can register names in bulk cheaply and bns price is still high",
+  name: "Ensure that controller can register names in bulk cheaply and bns price is still high",
   async fn(chain: Chain, accounts: Map<string, Account>) {
     const deployer = accounts.get("deployer")!.address;
     const account1 = accounts.get("wallet_1")!.address;

--- a/backend-public/tests/community-handles_names_test.ts
+++ b/backend-public/tests/community-handles_names_test.ts
@@ -237,10 +237,15 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "name-register",
-        ["0x67676767676767676767", "0x6767", types.principal(account1),"0x0102030405060708090a"],
+        [
+          "0x67676767676767676767",
+          "0x6767",
+          types.principal(account1),
+          "0x0102030405060708090a",
+        ],
         deployer
       ),
-     
+
       Tx.contractCall(
         "SP000000000000000000002Q6VF78.bns",
         "name-transfer",
@@ -270,7 +275,12 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "name-register",
-        ["0x67676767676767676767", "0x6767", types.principal(account1), "0x0102030405060708090a"],
+        [
+          "0x67676767676767676767",
+          "0x6767",
+          types.principal(account1),
+          "0x0102030405060708090a",
+        ],
         deployer
       ),
       Tx.contractCall(
@@ -297,10 +307,15 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "name-register",
-        ["0x67676767676767676767", "0x6767", types.principal(account1),"0x0102030405060708090a"],
+        [
+          "0x67676767676767676767",
+          "0x6767",
+          types.principal(account1),
+          "0x0102030405060708090a",
+        ],
         deployer
       ),
-     
+
       Tx.contractCall(
         "SP000000000000000000002Q6VF78.bns",
         "name-revoke",

--- a/backend-public/tests/community-handles_names_test.ts
+++ b/backend-public/tests/community-handles_names_test.ts
@@ -370,45 +370,6 @@ Clarinet.test({
 });
 
 Clarinet.test({
-  name: "Ensure that controller can register names in bulk cheaply and bns price is still high",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
-    const deployer = accounts.get("deployer")!.address;
-    const account1 = accounts.get("wallet_1")!.address;
-
-    setupNamespace(chain, deployer);
-
-    let block = chain.mineBlock([
-      Tx.contractCall(
-        "community-handles",
-        "bulk-name-register",
-        [
-          "0x67676767676767676767",
-          types.list([
-            types.tuple({
-              name: "0x6767",
-              "zonefile-hash": "0x0102030405060708090a",
-              owner: types.principal(account1),
-            }),
-          ]),
-        ],
-        deployer
-      ),
-    ]);
-    block.receipts[0].result.expectOk().expectBool(true);
-
-    const priceResponse = chain.callReadOnlyFn(
-      "SP000000000000000000002Q6VF78.bns",
-      "get-name-price",
-      ["0x67676767676767676767", "0x6767"],
-      account1
-    );
-    priceResponse.result
-      .expectOk()
-      .expectUint(9999999999999999999999999999990n);
-  },
-});
-
-Clarinet.test({
   name: "Ensure that user can't register name via bns cheaply",
   async fn(chain: Chain, accounts: Map<string, Account>) {
     const deployer = accounts.get("deployer")!.address;

--- a/backend-public/tests/community-handles_namespaces_test.ts
+++ b/backend-public/tests/community-handles_namespaces_test.ts
@@ -148,7 +148,7 @@ Clarinet.test({
       ),
 
       Tx.contractCall(
-        "ST000000000000000000002AMW42H.bns",
+        "SP000000000000000000002Q6VF78.bns",
         "namespace-revoke-function-price-edition",
         ["0x67676767676767676767"],
         deployer

--- a/backend-public/tests/community-handles_namespaces_test.ts
+++ b/backend-public/tests/community-handles_namespaces_test.ts
@@ -109,7 +109,7 @@ Clarinet.test({
       Tx.contractCall(
         "register-namespace",
         "do-it",
-        [types.some(types.principal(deployer))],
+        [types.some(types.principal(account1))],
         deployer
       ),
     ]);
@@ -121,74 +121,6 @@ Clarinet.test({
       ["0x67676767676767676767"],
       account1
     );
-    response.result.expectSome().expectPrincipal(deployer);
-  },
-});
-
-Clarinet.test({
-  name: "Ensure that controller can't register names after price function editing was revoked",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
-    const deployer = accounts.get("deployer")!.address;
-    const account1 = accounts.get("wallet_1")!.address;
-    const account2 = accounts.get("wallet_2")!.address;
-
-    setupNamespace(chain, deployer);
-
-    let block = chain.mineBlock([
-      Tx.contractCall(
-        "community-handles",
-        "name-register",
-        [
-          "0x67676767676767676767",
-          "0x6767",
-          types.principal(account1),
-          "0x0102030405060708090a",
-        ],
-        deployer
-      ),
-
-      Tx.contractCall(
-        "SP000000000000000000002Q6VF78.bns",
-        "namespace-revoke-function-price-edition",
-        ["0x67676767676767676767"],
-        deployer
-      ),
-
-      Tx.contractCall(
-        "community-handles",
-        "namespace-revoke-function-price-edition",
-        ["0x67676767676767676767"],
-        deployer
-      ),
-
-      Tx.contractCall(
-        "community-handles",
-        "name-register",
-        [
-          "0x67676767676767676767",
-          "0x6868",
-          types.principal(account2),
-          "0x0102030405060708090a",
-        ],
-        deployer
-      ),
-    ]);
-
-    // register name
-    block.receipts[0].result.expectOk().expectBool(true);
-    // try to block price function editing via bns
-    block.receipts[1].result
-      .expectErr()
-      // unauthorized because owned by contract
-      .expectInt(1011);
-
-    // do block price function editing via community handles
-    block.receipts[2].result.expectOk().expectBool(true);
-
-    // try to register a name for another user
-    block.receipts[3].result
-      .expectErr()
-      // unauthorized to change the price function for cheap name registration
-      .expectUint(1011);
+    response.result.expectSome().expectPrincipal(account1);
   },
 });

--- a/backend-public/tests/community-handles_namespaces_test.ts
+++ b/backend-public/tests/community-handles_namespaces_test.ts
@@ -98,3 +98,69 @@ Clarinet.test({
     response.result.expectSome().expectPrincipal(deployer);
   },
 });
+
+Clarinet.test({
+  name: "Ensure that controller can't register names after price function editing was revoked",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    const deployer = accounts.get("deployer")!.address;
+    const account1 = accounts.get("wallet_1")!.address;
+    const account2 = accounts.get("wallet_2")!.address;
+
+    setupNamespace(chain, deployer);
+
+    let block = chain.mineBlock([
+      Tx.contractCall(
+        "community-handles",
+        "name-register",
+        [
+          "0x67676767676767676767",
+          "0x6767",
+          types.principal(account1),
+          "0x0102030405060708090a",
+        ],
+        deployer
+      ),
+
+      Tx.contractCall(
+        "SP000000000000000000002Q6VF78.bns",
+        "namespace-revoke-function-price-edition",
+        ["0x67676767676767676767"],
+        deployer
+      ),
+
+      Tx.contractCall(
+        "community-handles",
+        "namespace-revoke-function-price-edition",
+        ["0x67676767676767676767"],
+        deployer
+      ),
+
+      Tx.contractCall(
+        "community-handles",
+        "name-register",
+        [
+          "0x67676767676767676767",
+          "0x6868",
+          types.principal(account2),
+          "0x0102030405060708090a",
+        ],
+        deployer
+      ),
+    ]);
+
+    // register name
+    block.receipts[0].result.expectOk().expectBool(true);
+    // try to block price function editing
+    block.receipts[1].result
+      .expectErr()
+      // unauthorized because owned by contract
+      .expectInt(1011);
+    // do block price function editing
+    block.receipts[2].result.expectOk().expectBool(true);
+    // try to register a name for another user
+    block.receipts[3].result
+      .expectErr()
+      // unauthorized to change the price function for cheap name registration
+      .expectUint(1011);
+  },
+});

--- a/backend-public/tests/preordering-namespace-owner_test.ts
+++ b/backend-public/tests/preordering-namespace-owner_test.ts
@@ -14,7 +14,10 @@ Clarinet.test({
       Tx.contractCall(
         "community-handles",
         "set-namespace-controller",
-        ["0x67676767676767676767", `'${deployer}.preordering-namespace-controller`],
+        [
+          "0x67676767676767676767",
+          `'${deployer}.preordering-namespace-controller`,
+        ],
         deployer
       ),
     ]);


### PR DESCRIPTION
This PR
* simplifies the community handle contract by removing the ownership
* adds name-preorder to approving-namespace-controller
* add name-renewal to approving-namespace-controller (limited to 100 renewals)