### PR TITLE
v2

### DIFF
--- a/backend-public/contracts/support-preorder.clar
+++ b/backend-public/contracts/support-preorder.clar
@@ -2,7 +2,7 @@
 (define-public (claim-preorder (old-hashed-salted-fqn (buff 20)) (hashed-salted-fqn (buff 20)) (owner principal) (new-owner principal))
   (begin
     (try! (contract-call? .ryder-handles-controller claim-fees old-hashed-salted-fqn owner))
-    (contract-call? .ryder-handles-controller name-preorder hashed-salted-fqn)))
+    (contract-call? .ryder-handles-controller name-preorder hashed-salted-fqn (some new-owner))))
 
 ;; register the preordered name and transfer to the new owner
 (define-public (register-transfer (namespace (buff 20))

--- a/backend-public/tests/ryder-handles-controller_test.ts
+++ b/backend-public/tests/ryder-handles-controller_test.ts
@@ -55,7 +55,7 @@ Clarinet.test({
       Tx.contractCall(
         "ryder-handles-controller",
         "name-preorder",
-        [hashResponse1.result],
+        [hashResponse1.result, types.none()],
         account1
       ),
       Tx.contractCall(
@@ -74,7 +74,7 @@ Clarinet.test({
       Tx.contractCall(
         "ryder-handles-controller",
         "name-preorder",
-        [hashResponse2.result],
+        [hashResponse2.result, types.none()],
         account2
       ),
       Tx.contractCall(
@@ -167,7 +167,7 @@ Clarinet.test({
       Tx.contractCall(
         "ryder-handles-controller",
         "name-preorder",
-        [hashResponse1.result],
+        [hashResponse1.result, types.none()],
         account1
       ),
       Tx.contractCall(
@@ -258,7 +258,7 @@ Clarinet.test({
       Tx.contractCall(
         "ryder-handles-controller",
         "name-preorder",
-        [hashResponse1.result],
+        [hashResponse1.result, types.none()],
         account1
       ),
     ]);
@@ -294,6 +294,18 @@ Clarinet.test({
 
     block.receipts[0].result.expectErr().expectUint(503); // too early
 
+    // try to claim fees using a different key
+    block = chain.mineBlock([
+      Tx.contractCall(
+        "ryder-handles-controller",
+        "claim-fees",
+        [hashResponse1.result, types.principal(account2)],
+        account2
+      ),
+    ]);
+
+    block.receipts[0].result.expectErr().expectUint(404);
+
     // claim fees
     block = chain.mineBlock([
       Tx.contractCall(
@@ -311,6 +323,18 @@ Clarinet.test({
       `${deployer}.ryder-handles-controller`,
       deployer
     );
+
+    // try to claim fees again
+    block = chain.mineBlock([
+      Tx.contractCall(
+        "ryder-handles-controller",
+        "claim-fees",
+        [hashResponse1.result, types.principal(account1)],
+        account2
+      ),
+    ]);
+
+    block.receipts[0].result.expectErr().expectUint(502); // err-invalid-claim
   },
 });
 
@@ -353,7 +377,7 @@ Clarinet.test({
       Tx.contractCall(
         "ryder-handles-controller",
         "name-preorder",
-        [hashResponse1.result],
+        [hashResponse1.result, types.none()],
         account1
       ),
       Tx.contractCall(

--- a/backend-public/tests/ryder-handles-controller_test.ts
+++ b/backend-public/tests/ryder-handles-controller_test.ts
@@ -1,6 +1,31 @@
 import { Clarinet, Tx, Chain, Account, types } from "./deps.ts";
 import { setupNamespace, setupNamespace2 } from "./utils.ts";
 
+const setupNamespaceController = (chain: Chain, deployer: string) => {
+  let block = chain.mineBlock([
+    Tx.contractCall(
+      "community-handles",
+      "set-namespace-controller",
+      ["0x67676767676767676767", `'${deployer}.ryder-handles-controller`],
+      deployer
+    ),
+  ]);
+
+  block.receipts[0].result.expectOk().expectBool(true);
+};
+
+const setupNamespaceController2 = (chain: Chain, deployer: string) => {
+  let block = chain.mineBlock([
+    Tx.contractCall(
+      "community-handles",
+      "set-namespace-controller",
+      ["0x68686868686868686868", `'${deployer}.ryder-handles-controller`],
+      deployer
+    ),
+  ]);
+  block.receipts[0].result.expectOk().expectBool(true);
+};
+
 Clarinet.test({
   name: "Ensure that users can register approved names",
   async fn(chain: Chain, accounts: Map<string, Account>) {
@@ -11,23 +36,8 @@ Clarinet.test({
     setupNamespace2(chain, deployer);
     setupNamespace(chain, deployer);
 
-    let block = chain.mineBlock([
-      Tx.contractCall(
-        "community-handles",
-        "set-namespace-controller",
-        ["0x67676767676767676767", `'${deployer}.ryder-handles-controller`],
-        deployer
-      ),
-      Tx.contractCall(
-        "community-handles",
-        "set-namespace-controller",
-        ["0x68686868686868686868", `'${deployer}.ryder-handles-controller`],
-        deployer
-      ),
-    ]);
-
-    block.receipts[0].result.expectOk().expectBool(true);
-    block.receipts[1].result.expectOk().expectBool(true);
+    setupNamespaceController(chain, deployer);
+    setupNamespaceController2(chain, deployer);
 
     const hashResponse1 = chain.callReadOnlyFn(
       "crypto",
@@ -43,7 +53,7 @@ Clarinet.test({
       deployer
     );
 
-    block = chain.mineBlock([
+    let block = chain.mineBlock([
       Tx.contractCall(
         "ryder-handles-controller",
         "set-approval-pubkey",
@@ -69,7 +79,7 @@ Clarinet.test({
           types.principal(account1),
           "0x01020304",
         ],
-        account1
+        account1 // called by name buyer
       ),
       Tx.contractCall(
         "ryder-handles-controller",
@@ -88,13 +98,13 @@ Clarinet.test({
           types.principal(account2),
           "0x01020304",
         ],
-        deployer
+        deployer // called by different user
       ),
     ]);
 
     block.receipts[0].result.expectOk().expectBool(true);
     // preorder and register a name
-    block.receipts[1].result.expectOk().expectUint(148);
+    block.receipts[1].result.expectOk().expectUint(149);
     block.receipts[2].result.expectOk().expectBool(true);
 
     // fees are sent to controller-admin and escrow on preorder
@@ -117,8 +127,111 @@ Clarinet.test({
     );
 
     // preorder and register a second name
-    block.receipts[3].result.expectOk().expectUint(148);
+    block.receipts[3].result.expectOk().expectUint(149);
     block.receipts[4].result.expectOk().expectBool(true);
+  },
+});
+
+
+
+Clarinet.test({
+  name: "Ensure that users can preorder and register names for other users",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    const deployer = accounts.get("deployer")!.address;
+    const account1 = accounts.get("wallet_1")!.address;
+    const account2 = accounts.get("wallet_2")!.address;
+
+    setupNamespace2(chain, deployer);
+    setupNamespace(chain, deployer);
+
+    setupNamespaceController(chain, deployer);
+    setupNamespaceController2(chain, deployer);
+
+    const hashResponse1 = chain.callReadOnlyFn(
+      "crypto",
+      "crypto-hash160",
+      ["0x31312e6767676767676767676700"],
+      deployer
+    );
+
+    const hashResponse2 = chain.callReadOnlyFn(
+      "crypto",
+      "crypto-hash160",
+      ["0x32322e6767676767676767676700"],
+      deployer
+    );
+
+    let block = chain.mineBlock([
+      Tx.contractCall(
+        "ryder-handles-controller",
+        "set-approval-pubkey",
+        [
+          "0x02a3b986401a619013ee1deee0ccba58a5b2235260d55259106e5fc9c53e6a9d71",
+        ],
+        deployer
+      ),
+      Tx.contractCall(
+        "ryder-handles-controller",
+        "name-preorder",
+        [hashResponse1.result, types.some(types.principal(account2))],
+        account1
+      ),
+      // try with wrong name buyer
+      Tx.contractCall(
+        "ryder-handles-controller",
+        "name-register",
+        [
+          "0x67676767676767676767",
+          "0x3131",
+          "0x00",
+          "0xd693e8d1d558a5aabff258de2bd5ec6da5eea52ec9b45e4c2c9f34aa547cabb3235ad7223adf3a8d4e51f3cd7fbefdc001fcee9d3e8ddda4643c42dcea07bb6700",
+          types.principal(account1),
+          "0x01020304",
+        ],
+        account1
+      ),
+      // register name with provided buyer
+      Tx.contractCall(
+        "ryder-handles-controller",
+        "name-register",
+        [
+          "0x67676767676767676767",
+          "0x3131",
+          "0x00",
+          "0xd693e8d1d558a5aabff258de2bd5ec6da5eea52ec9b45e4c2c9f34aa547cabb3235ad7223adf3a8d4e51f3cd7fbefdc001fcee9d3e8ddda4643c42dcea07bb6700",
+          types.principal(account2),
+          "0x01020304",
+        ],
+        deployer
+      ),
+    ]);
+
+    block.receipts[0].result.expectOk().expectBool(true);
+    // preorder 
+    block.receipts[1].result.expectOk().expectUint(149);
+    // try to register for wrong user
+    block.receipts[2].result.expectErr().expectUint(404);
+    // register for provided user
+    block.receipts[3].result.expectOk().expectBool(true);
+
+    // fees are sent to controller-admin and escrow on preorder
+    block.receipts[1].events.expectSTXTransferEvent(
+      6999999,
+      account1,
+      deployer
+    );
+    block.receipts[1].events.expectSTXTransferEvent(
+      3000000,
+      account1,
+      `${deployer}.ryder-handles-controller`
+    );
+
+    // fees in escrow are sent to community treasury on register
+    block.receipts[3].events.expectSTXTransferEvent(
+      3000000,
+      `${deployer}.ryder-handles-controller`,
+      deployer
+    );
   },
 });
 
@@ -131,16 +244,7 @@ Clarinet.test({
 
     setupNamespace(chain, deployer);
 
-    let block = chain.mineBlock([
-      Tx.contractCall(
-        "community-handles",
-        "set-namespace-controller",
-        ["0x67676767676767676767", `'${deployer}.ryder-handles-controller`],
-        deployer
-      ),
-    ]);
-
-    block.receipts[0].result.expectOk().expectBool(true);
+    setupNamespaceController(chain, deployer);
 
     const hashResponse1 = chain.callReadOnlyFn(
       "crypto",
@@ -149,7 +253,7 @@ Clarinet.test({
       deployer
     );
 
-    block = chain.mineBlock([
+    let block = chain.mineBlock([
       Tx.contractCall(
         "ryder-handles-controller",
         "set-approval-pubkey",
@@ -221,17 +325,7 @@ Clarinet.test({
     const account2 = accounts.get("wallet_2")!.address;
 
     setupNamespace(chain, deployer);
-
-    let block = chain.mineBlock([
-      Tx.contractCall(
-        "community-handles",
-        "set-namespace-controller",
-        ["0x67676767676767676767", `'${deployer}.ryder-handles-controller`],
-        deployer
-      ),
-    ]);
-
-    block.receipts[0].result.expectOk().expectBool(true);
+    setupNamespaceController(chain, deployer);
 
     const hashResponse1 = chain.callReadOnlyFn(
       "crypto",
@@ -240,7 +334,7 @@ Clarinet.test({
       deployer
     );
 
-    block = chain.mineBlock([
+    let block = chain.mineBlock([
       Tx.contractCall(
         "ryder-handles-controller",
         "set-approval-pubkey",
@@ -346,17 +440,7 @@ Clarinet.test({
     const account2 = accounts.get("wallet_2")!.address;
 
     setupNamespace(chain, deployer);
-
-    let block = chain.mineBlock([
-      Tx.contractCall(
-        "community-handles",
-        "set-namespace-controller",
-        ["0x67676767676767676767", `'${deployer}.ryder-handles-controller`],
-        deployer
-      ),
-    ]);
-
-    block.receipts[0].result.expectOk().expectBool(true);
+    setupNamespaceController(chain, deployer);
 
     const hashResponse1 = chain.callReadOnlyFn(
       "crypto",
@@ -365,7 +449,7 @@ Clarinet.test({
       deployer
     );
 
-    block = chain.mineBlock([
+    let block = chain.mineBlock([
       Tx.contractCall(
         "ryder-handles-controller",
         "set-approval-pubkey",
@@ -481,19 +565,9 @@ Clarinet.test({
     const account2 = accounts.get("wallet_2")!.address;
 
     setupNamespace2(chain, deployer);
+    setupNamespaceController2(chain, deployer);
 
     let block = chain.mineBlock([
-      Tx.contractCall(
-        "community-handles",
-        "set-namespace-controller",
-        ["0x68686868686868686868", `'${deployer}.ryder-handles-controller`],
-        deployer
-      ),
-    ]);
-
-    block.receipts[0].result.expectOk().expectBool(true);
-
-    block = chain.mineBlock([
       Tx.contractCall(
         "ryder-handles-controller",
         "set-namespace-controller",

--- a/backend-public/tests/utils.ts
+++ b/backend-public/tests/utils.ts
@@ -4,7 +4,7 @@ export function setupNamespace(chain: Chain, deployer: string) {
   const hashResponse = chain.callReadOnlyFn(
     "crypto",
     "crypto-hash160",
-    ["0x6767676767676767676700"],
+    ["0x6767676767676767676700"], // namespace + salt 0x00
     deployer
   );
 

--- a/bns-v2/.gitignore
+++ b/bns-v2/.gitignore
@@ -1,0 +1,5 @@
+
+**/settings/Mainnet.toml
+**/settings/Testnet.toml
+.requirements/
+history.txt

--- a/bns-v2/.vscode/settings.json
+++ b/bns-v2/.vscode/settings.json
@@ -1,0 +1,5 @@
+
+{
+    "deno.enable": true,
+    "files.eol": "\n"
+}

--- a/bns-v2/.vscode/tasks.json
+++ b/bns-v2/.vscode/tasks.json
@@ -1,0 +1,18 @@
+
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "check contracts",
+            "group": "test",
+            "type": "shell",
+            "command": "clarinet check"
+        },
+        {
+            "label": "test contracts",
+            "group": "test",
+            "type": "shell",
+            "command": "clarinet test"
+        }
+    ]
+}

--- a/bns-v2/Clarinet.toml
+++ b/bns-v2/Clarinet.toml
@@ -5,8 +5,19 @@ authors = []
 telemetry = false
 cache_dir = "./.requirements"
 
-# [contracts.counter]
-# path = "contracts/counter.clar"
+[contracts.bns-registry]
+path = "contracts/bns-registry.clar"
+
+[contracts.bns]
+path = "contracts/bns.clar"
+
+
+[contracts.sell-bns]
+path = "contracts/sell-bns.clar"
+
+[contracts.crypto]
+path = "contracts/external/crypto.clar"
+depends_on = []
 
 [repl.analysis]
 passes = ["check_checker"]

--- a/bns-v2/Clarinet.toml
+++ b/bns-v2/Clarinet.toml
@@ -1,0 +1,21 @@
+
+[project]
+name = "bns-v2"
+authors = []
+telemetry = false
+cache_dir = "./.requirements"
+
+# [contracts.counter]
+# path = "contracts/counter.clar"
+
+[repl.analysis]
+passes = ["check_checker"]
+check_checker = { trusted_sender = false, trusted_caller = false, callee_filter = false }
+
+# Check-checker settings:
+# trusted_sender: if true, inputs are trusted after tx_sender has been checked.
+# trusted_caller: if true, inputs are trusted after contract-caller has been checked.
+# callee_filter: if true, untrusted data may be passed into a private function without a
+# warning, if it gets checked inside. This check will also propagate up to the
+# caller.
+# More informations: https://www.hiro.so/blog/new-safety-checks-in-clarinet

--- a/bns-v2/contracts/bns-registry.clar
+++ b/bns-v2/contracts/bns-registry.clar
@@ -1,17 +1,19 @@
 (define-data-var controller principal tx-sender)
-(define-map bns uint principal)
-(define-data-var version uint 0)
+(define-map bns-versions uint principal)
+(define-data-var version uint u0)
+
+(define-constant err-not-authorized (err 403))
 
 (define-public (set-next-version (bns principal))
     (let ((new-version (+ u1 (var-get version))))
-        (asssert! (is-eq contract-caller (var-get controller)))
+        (asserts! (is-eq contract-caller (var-get controller)) err-not-authorized)
         (var-set version new-version)
-        (map-set bns new-version bns)
+        (map-set bns-versions new-version bns)
         (ok true)))
 
 (define-public (set-controller (new-controller principal))
     (begin
-        (assert! (is-eq contract-caller (var-get controller)))
+        (asserts! (is-eq contract-caller (var-get controller)) err-not-authorized)
         (var-set controller new-controller)
         (ok true)))
 
@@ -19,7 +21,7 @@
     (var-get version))
 
 (define-read-only (get-bns)
-    (unwrap-panic (map-get? bns (get-version))))
+    (unwrap-panic (map-get? bns-versions (get-version))))
 
 (define-read-only (get-controller)
     (var-get controller))

--- a/bns-v2/contracts/bns-registry.clar
+++ b/bns-v2/contracts/bns-registry.clar
@@ -1,0 +1,25 @@
+(define-data-var controller principal tx-sender)
+(define-map bns uint principal)
+(define-data-var version uint 0)
+
+(define-public (set-next-version (bns principal))
+    (let ((new-version (+ u1 (var-get version))))
+        (asssert! (is-eq contract-caller (var-get controller)))
+        (var-set version new-version)
+        (map-set bns new-version bns)
+        (ok true)))
+
+(define-public (set-controller (new-controller principal))
+    (begin
+        (assert! (is-eq contract-caller (var-get controller)))
+        (var-set controller new-controller)
+        (ok true)))
+
+(define-read-only (get-version)
+    (var-get version))
+
+(define-read-only (get-bns)
+    (unwrap-panic (map-get? bns (get-version))))
+
+(define-read-only (get-controller)
+    (var-get controller))

--- a/bns-v2/contracts/bns.clar
+++ b/bns-v2/contracts/bns.clar
@@ -1,0 +1,966 @@
+;;;; Errors
+(define-constant ERR_PANIC 0)
+(define-constant ERR_NAMESPACE_PREORDER_NOT_FOUND 1001)
+(define-constant ERR_NAMESPACE_PREORDER_EXPIRED 1002)
+(define-constant ERR_NAMESPACE_PREORDER_ALREADY_EXISTS 1003)
+(define-constant ERR_NAMESPACE_UNAVAILABLE 1004)
+(define-constant ERR_NAMESPACE_NOT_FOUND 1005)
+(define-constant ERR_NAMESPACE_ALREADY_EXISTS 1006)
+(define-constant ERR_NAMESPACE_NOT_LAUNCHED 1007)
+(define-constant ERR_NAMESPACE_PRICE_FUNCTION_INVALID 1008)
+(define-constant ERR_NAMESPACE_PREORDER_CLAIMABILITY_EXPIRED 1009)
+(define-constant ERR_NAMESPACE_PREORDER_LAUNCHABILITY_EXPIRED 1010)
+(define-constant ERR_NAMESPACE_OPERATION_UNAUTHORIZED 1011)
+(define-constant ERR_NAMESPACE_STX_BURNT_INSUFFICIENT 1012)
+(define-constant ERR_NAMESPACE_BLANK 1013)
+(define-constant ERR_NAMESPACE_ALREADY_LAUNCHED 1014)
+(define-constant ERR_NAMESPACE_HASH_MALFORMED 1015)
+(define-constant ERR_NAMESPACE_CHARSET_INVALID 1016)
+
+(define-constant ERR_NAME_PREORDER_NOT_FOUND 2001)
+(define-constant ERR_NAME_PREORDER_EXPIRED 2002)
+(define-constant ERR_NAME_PREORDER_FUNDS_INSUFFICIENT 2003)
+(define-constant ERR_NAME_UNAVAILABLE 2004)
+(define-constant ERR_NAME_OPERATION_UNAUTHORIZED 2006)
+(define-constant ERR_NAME_STX_BURNT_INSUFFICIENT 2007)
+(define-constant ERR_NAME_EXPIRED 2008)
+(define-constant ERR_NAME_GRACE_PERIOD 2009)
+(define-constant ERR_NAME_BLANK 2010)
+(define-constant ERR_NAME_ALREADY_CLAIMED 2011)
+(define-constant ERR_NAME_CLAIMABILITY_EXPIRED 2012)
+(define-constant ERR_NAME_NOT_FOUND 2013)
+(define-constant ERR_NAME_REVOKED 2014)
+(define-constant ERR_NAME_TRANSFER_FAILED 2015)
+(define-constant ERR_NAME_PREORDER_ALREADY_EXISTS 2016)
+(define-constant ERR_NAME_HASH_MALFORMED 2017)
+(define-constant ERR_NAME_PREORDERED_BEFORE_NAMESPACE_LAUNCH 2018)
+(define-constant ERR_NAME_NOT_RESOLVABLE 2019)
+(define-constant ERR_NAME_COULD_NOT_BE_MINTED 2020)
+(define-constant ERR_NAME_COULD_NOT_BE_TRANSFERED 2021)
+(define-constant ERR_NAME_CHARSET_INVALID 2022)
+
+(define-constant ERR_PRINCIPAL_ALREADY_ASSOCIATED 3001)
+(define-constant ERR_INSUFFICIENT_FUNDS 4001)
+
+(define-constant NAMESPACE_PREORDER_CLAIMABILITY_TTL u144)
+(define-constant NAMESPACE_LAUNCHABILITY_TTL u52595)
+(define-constant NAME_PREORDER_CLAIMABILITY_TTL u144)
+(define-constant NAME_GRACE_PERIOD_DURATION u5000)
+
+(define-data-var attachment-index uint u0)
+
+;; Price tables
+(define-constant NAMESPACE_PRICE_TIERS (list
+  u640000000000
+  u64000000000 u64000000000 
+  u6400000000 u6400000000 u6400000000 u6400000000 
+  u640000000 u640000000 u640000000 u640000000 u640000000 u640000000 u640000000 u640000000 u640000000 u640000000 u640000000 u640000000 u640000000))
+
+;;;; Data
+(define-map namespaces
+  (buff 20)
+  { namespace-import: principal,
+    revealed-at: uint,
+    launched-at: (optional uint),
+    lifetime: uint,
+    can-update-price-function: bool,
+    price-function: {
+      buckets: (list 16 uint),
+      base: uint, 
+      coeff: uint, 
+      nonalpha-discount: uint, 
+      no-vowel-discount: uint
+    }
+  })
+
+(define-map namespace-preorders
+  { hashed-salted-namespace: (buff 20), buyer: principal }
+  { created-at: uint, claimed: bool, stx-burned: uint })
+
+(define-non-fungible-token names { name: (buff 48), namespace: (buff 20) })
+
+;; Rule 1-1 -> 1 principal, 1 name
+(define-map owner-name principal { name: (buff 48), namespace: (buff 20) })
+;; Only applies to non-revoked, non-expired names. 
+;; A principal can own many expired names (but they will be transferred away once someone re-registers them), 
+;; and can own many revoked names (but they do not resolve and cannot be transferred or updated).
+
+(define-map name-properties
+  { name: (buff 48), namespace: (buff 20) }
+  { registered-at: (optional uint),
+    imported-at: (optional uint),
+    revoked-at: (optional uint),
+    zonefile-hash: (buff 20) })
+
+(define-map name-preorders
+  { hashed-salted-fqn: (buff 20), buyer: principal }
+  { created-at: uint, claimed: bool, stx-burned: uint })
+
+(define-private (min (a uint) (b uint))
+  (if (<= a b) a b))
+
+(define-private (max (a uint) (b uint))
+  (if (> a b) a b))
+
+(define-private (get-exp-at-index (buckets (list 16 uint)) (index uint))
+  (unwrap-panic (element-at buckets index)))
+
+(define-private (is-digit (char (buff 1)))
+  (or 
+    (is-eq char 0x30) ;; 0
+    (is-eq char 0x31) ;; 1
+    (is-eq char 0x32) ;; 2
+    (is-eq char 0x33) ;; 3
+    (is-eq char 0x34) ;; 4
+    (is-eq char 0x35) ;; 5
+    (is-eq char 0x36) ;; 6
+    (is-eq char 0x37) ;; 7
+    (is-eq char 0x38) ;; 8
+    (is-eq char 0x39))) ;; 9
+
+(define-private (is-lowercase-alpha (char (buff 1)))
+  (or 
+    (is-eq char 0x61) ;; a
+    (is-eq char 0x62) ;; b
+    (is-eq char 0x63) ;; c
+    (is-eq char 0x64) ;; d
+    (is-eq char 0x65) ;; e
+    (is-eq char 0x66) ;; f
+    (is-eq char 0x67) ;; g
+    (is-eq char 0x68) ;; h
+    (is-eq char 0x69) ;; i
+    (is-eq char 0x6a) ;; j
+    (is-eq char 0x6b) ;; k
+    (is-eq char 0x6c) ;; l
+    (is-eq char 0x6d) ;; m
+    (is-eq char 0x6e) ;; n
+    (is-eq char 0x6f) ;; o
+    (is-eq char 0x70) ;; p
+    (is-eq char 0x71) ;; q
+    (is-eq char 0x72) ;; r
+    (is-eq char 0x73) ;; s
+    (is-eq char 0x74) ;; t
+    (is-eq char 0x75) ;; u
+    (is-eq char 0x76) ;; v
+    (is-eq char 0x77) ;; w
+    (is-eq char 0x78) ;; x
+    (is-eq char 0x79) ;; y
+    (is-eq char 0x7a))) ;; z
+
+(define-private (is-vowel (char (buff 1)))
+  (or 
+    (is-eq char 0x61) ;; a
+    (is-eq char 0x65) ;; e
+    (is-eq char 0x69) ;; i
+    (is-eq char 0x6f) ;; o
+    (is-eq char 0x75) ;; u
+    (is-eq char 0x79))) ;; y
+
+(define-private (is-special-char (char (buff 1)))
+  (or 
+    (is-eq char 0x2d) ;; -
+    (is-eq char 0x5f))) ;; _
+
+(define-private (is-char-valid (char (buff 1)))
+  (or 
+    (is-lowercase-alpha char)
+    (is-digit char)
+    (is-special-char char)))
+
+(define-private (is-nonalpha (char (buff 1)))
+  (or 
+    (is-digit char)
+    (is-special-char char)))
+
+(define-private (has-vowels-chars (name (buff 48)))
+  (> (len (filter is-vowel name)) u0))
+
+(define-private (has-nonalpha-chars (name (buff 48)))
+  (> (len (filter is-nonalpha name)) u0))
+
+(define-private (has-invalid-chars (name (buff 48)))
+  (< (len (filter is-char-valid name)) (len name)))
+
+(define-private (name-lease-started-at? (namespace-launched-at (optional uint)) 
+                                        (namespace-revealed-at uint)
+                                        (name-props (tuple 
+                                                  (registered-at (optional uint))
+                                                  (imported-at (optional uint))
+                                                  (revoked-at (optional uint))
+                                                  (zonefile-hash (buff 20)))))
+      (let ((registered-at (get registered-at name-props))
+            (imported-at (get imported-at name-props)))
+        (if (is-none namespace-launched-at)
+          (begin
+            ;; The namespace must not be expired
+            (asserts! 
+              (> (+ namespace-revealed-at NAMESPACE_LAUNCHABILITY_TTL) block-height) 
+              (err ERR_NAMESPACE_PREORDER_LAUNCHABILITY_EXPIRED))
+            (ok (unwrap-panic imported-at)))
+          (begin
+            ;; The namespace must be launched
+            (asserts! (is-some namespace-launched-at) (err ERR_NAMESPACE_NOT_LAUNCHED))
+            ;; Sanity check: the name must have been either be registered or imported
+            (asserts! (is-eq (xor 
+              (match registered-at res 1 0)
+              (match imported-at   res 1 0)) 1) (err ERR_PANIC))
+            ;; If the name was launched, then started-at will come from registered-at
+            (if (is-some registered-at)
+              ;; The name was registered - We return the registration block height
+              (ok (unwrap-panic registered-at))
+              ;; The name was imported
+              (if (and (>= (unwrap-panic imported-at) namespace-revealed-at)
+                      (<= (unwrap-panic imported-at) (unwrap-panic namespace-launched-at)))
+                ;; The name was imported after revealing the namespace and before launching the namespace - We return the launch block height
+                (ok (unwrap-panic namespace-launched-at))
+                (ok u0)))))))
+
+;; Note: the following method is used in name-import and name-register. The latter ensure that the name
+;; can be registered, the former does not. 
+(define-private (mint-or-transfer-name? (namespace (buff 20)) (name (buff 48)) (beneficiary principal))
+    (let (
+      (current-owner (nft-get-owner? names (tuple (name name) (namespace namespace)))))
+      ;; The principal can register a name
+      (asserts!
+        (try! (can-receive-name beneficiary))
+        (err ERR_PRINCIPAL_ALREADY_ASSOCIATED))
+      (if (is-none current-owner)
+        ;; This is a new name, let's mint it
+        (begin
+          (unwrap! 
+            (nft-mint?
+              names 
+              { name: name, namespace: namespace }
+              beneficiary)
+            (err ERR_NAME_COULD_NOT_BE_MINTED))
+          (map-set owner-name
+            beneficiary
+            { name: name, namespace: namespace })
+          (ok true))
+        (update-name-ownership? namespace name (unwrap-panic current-owner) beneficiary))))
+
+(define-private (update-name-ownership? (namespace (buff 20)) 
+                                        (name (buff 48)) 
+                                        (from principal) 
+                                        (to principal))
+  (if (is-eq from to)
+    (ok true)
+    (begin
+      (unwrap!
+        (nft-transfer? names { name: name, namespace: namespace } from to)
+        (err ERR_NAME_COULD_NOT_BE_TRANSFERED))
+      (map-delete owner-name from)
+      (map-set owner-name
+        to
+        { name: name, namespace: namespace })
+      (ok true))))
+
+(define-private (update-zonefile-and-props (namespace (buff 20))
+                                           (name (buff 48))
+                                           (registered-at (optional uint)) 
+                                           (imported-at (optional uint)) 
+                                           (revoked-at (optional uint)) 
+                                           (zonefile-hash (buff 20))
+                                           (op (string-ascii 16)))
+  (let 
+    ((current-index (var-get attachment-index)))
+      ;; Emit event used as a system hinter
+      (print {
+        attachment: {
+          hash: zonefile-hash,
+          attachment-index: current-index,
+          metadata: {
+            name: name,
+            namespace: namespace,
+            tx-sender: tx-sender,
+            op: op
+          }
+        }})
+      ;; Update cursor
+      (var-set attachment-index (+ u1 current-index))
+      (map-set name-properties
+        { name: name, namespace: namespace }
+        { registered-at: registered-at,
+          imported-at: imported-at,
+          revoked-at: revoked-at,
+          zonefile-hash: zonefile-hash })))
+
+(define-private (is-namespace-available (namespace (buff 20)))
+  (match (map-get? namespaces namespace) namespace-props
+    (begin
+      ;; Is the namespace launched?
+      (if (is-some (get launched-at namespace-props)) 
+        false
+        (> block-height (+ (get revealed-at namespace-props) NAMESPACE_LAUNCHABILITY_TTL)))) ;; Is the namespace expired?
+    true))
+
+(define-private (compute-name-price (name (buff 48))
+                                    (price-function (tuple (buckets (list 16 uint)) 
+                                                           (base uint) 
+                                                           (coeff uint) 
+                                                           (nonalpha-discount uint) 
+                                                           (no-vowel-discount uint))))
+  (let (
+    (exponent (get-exp-at-index (get buckets price-function) (min u15 (- (len name) u1))))
+    (no-vowel-discount (if (not (has-vowels-chars name)) (get no-vowel-discount price-function) u1))
+    (nonalpha-discount (if (has-nonalpha-chars name) (get nonalpha-discount price-function) u1)))
+    (*
+      (/
+        (*
+          (get coeff price-function)
+          (pow (get base price-function) exponent))
+        (max nonalpha-discount no-vowel-discount))
+      u10)))
+
+;;;; NAMESPACES
+;; NAMESPACE_PREORDER
+;; This step registers the salted hash of the namespace with BNS nodes, and burns the requisite amount of cryptocurrency.
+;; Additionally, this step proves to the BNS nodes that user has honored the BNS consensus rules by including a recent
+;; consensus hash in the transaction.
+;; Returns pre-order's expiration date (in blocks).
+(define-public (namespace-preorder (hashed-salted-namespace (buff 20))
+                                   (stx-to-burn uint))
+  (let 
+    ((former-preorder 
+      (map-get? namespace-preorders { hashed-salted-namespace: hashed-salted-namespace, buyer: tx-sender })))
+    ;; Ensure eventual former pre-order expired 
+    (asserts! 
+      (if (is-none former-preorder)
+        true
+        (>= block-height (+ NAMESPACE_PREORDER_CLAIMABILITY_TTL
+                            (unwrap-panic (get created-at former-preorder)))))
+      (err ERR_NAMESPACE_PREORDER_ALREADY_EXISTS))
+    ;; Ensure that the hashed namespace is 20 bytes long
+    (asserts! (is-eq (len hashed-salted-namespace) u20) (err ERR_NAMESPACE_HASH_MALFORMED))
+    ;; Ensure that user will be burning a positive amount of tokens
+    (asserts! (> stx-to-burn u0) (err ERR_NAMESPACE_STX_BURNT_INSUFFICIENT))
+    ;; Burn the tokens
+    (unwrap! (stx-burn? stx-to-burn tx-sender) (err ERR_INSUFFICIENT_FUNDS))
+    ;; Register the preorder
+    (map-set namespace-preorders
+      { hashed-salted-namespace: hashed-salted-namespace, buyer: tx-sender }
+      { created-at: block-height, claimed: false, stx-burned: stx-to-burn })
+    (ok (+ block-height NAMESPACE_PREORDER_CLAIMABILITY_TTL))))
+
+;; NAMESPACE_REVEAL
+;; This second step reveals the salt and the namespace ID (pairing it with its NAMESPACE_PREORDER). It reveals how long
+;; names last in this namespace before they expire or must be renewed, and it sets a price function for the namespace
+;; that determines how cheap or expensive names its will be.
+(define-public (namespace-reveal (namespace (buff 20))
+                                 (namespace-salt (buff 20))
+                                 (p-func-base uint)
+                                 (p-func-coeff uint)
+                                 (p-func-b1 uint)
+                                 (p-func-b2 uint)
+                                 (p-func-b3 uint)
+                                 (p-func-b4 uint)
+                                 (p-func-b5 uint)
+                                 (p-func-b6 uint)
+                                 (p-func-b7 uint)
+                                 (p-func-b8 uint)
+                                 (p-func-b9 uint)
+                                 (p-func-b10 uint)
+                                 (p-func-b11 uint)
+                                 (p-func-b12 uint)
+                                 (p-func-b13 uint)
+                                 (p-func-b14 uint)
+                                 (p-func-b15 uint)
+                                 (p-func-b16 uint)
+                                 (p-func-non-alpha-discount uint)
+                                 (p-func-no-vowel-discount uint)
+                                 (lifetime uint)
+                                 (namespace-import principal))
+  ;; The salt and namespace must hash to a preorder entry in the `namespace_preorders` table.
+  ;; The sender must match the principal in the preorder entry (implied)
+  (let (
+    (hashed-salted-namespace (hash160 (concat namespace namespace-salt)))
+    (price-function (tuple 
+      (buckets (list
+        p-func-b1
+        p-func-b2
+        p-func-b3
+        p-func-b4
+        p-func-b5
+        p-func-b6
+        p-func-b7
+        p-func-b8
+        p-func-b9
+        p-func-b10
+        p-func-b11
+        p-func-b12
+        p-func-b13
+        p-func-b14
+        p-func-b15
+        p-func-b16))
+      (base p-func-base)
+      (coeff p-func-coeff)
+      (nonalpha-discount p-func-non-alpha-discount)
+      (no-vowel-discount p-func-no-vowel-discount)))
+    (preorder (unwrap!
+      (map-get? namespace-preorders { hashed-salted-namespace: hashed-salted-namespace, buyer: tx-sender })
+      (err ERR_NAMESPACE_PREORDER_NOT_FOUND)))
+    (namespace-price (try! (get-namespace-price namespace))))
+    ;; The namespace must only have valid chars
+    (asserts!
+      (not (has-invalid-chars namespace))
+      (err ERR_NAMESPACE_CHARSET_INVALID))
+    ;; The namespace must not exist in the `namespaces` table, or be expired
+    (asserts! 
+      (is-namespace-available namespace)
+      (err ERR_NAMESPACE_ALREADY_EXISTS))
+    ;; The amount burnt must be equal to or greater than the cost of the namespace
+    (asserts!
+      (>= (get stx-burned preorder) namespace-price)
+      (err ERR_NAMESPACE_STX_BURNT_INSUFFICIENT))
+    ;; This transaction must arrive within 24 hours of its `NAMESPACE_PREORDER`
+    (asserts!
+      (< block-height (+ (get created-at preorder) NAMESPACE_PREORDER_CLAIMABILITY_TTL))
+      (err ERR_NAMESPACE_PREORDER_CLAIMABILITY_EXPIRED))
+    ;; The preorder record for this namespace will be marked as "claimed"
+    (map-set namespace-preorders
+      { hashed-salted-namespace: hashed-salted-namespace, buyer: tx-sender }
+      { created-at: (get created-at preorder), claimed: true, stx-burned: (get stx-burned preorder) })
+    ;; The namespace will be set as "revealed" but not "launched", its price function, its renewal rules, its version,
+    ;; and its import principal will be written to the  `namespaces` table.
+    (map-set namespaces
+      namespace
+      { namespace-import: namespace-import,
+        revealed-at: block-height,
+        launched-at: none,
+        lifetime: lifetime,
+        can-update-price-function: true,
+        price-function: price-function })
+    (ok true)))
+
+;; NAME_IMPORT
+;; Once a namespace is revealed, the user has the option to populate it with a set of names. Each imported name is given
+;; both an owner and some off-chain state. This step is optional; Namespace creators are not required to import names.
+(define-public (name-import (namespace (buff 20))
+                            (name (buff 48))
+                            (beneficiary principal)
+                            (zonefile-hash (buff 20)))
+  (let (
+    (namespace-props (unwrap!
+      (map-get? namespaces namespace)
+      (err ERR_NAMESPACE_NOT_FOUND))))
+      ;; The name must only have valid chars
+      (asserts!
+        (not (has-invalid-chars name))
+        (err ERR_NAME_CHARSET_INVALID))
+      ;; The sender principal must match the namespace's import principal
+      (asserts!
+        (is-eq (get namespace-import namespace-props) tx-sender)
+        (err ERR_NAMESPACE_OPERATION_UNAUTHORIZED))
+      ;; The name's namespace must not be launched
+      (asserts!
+        (is-none (get launched-at namespace-props))
+        (err ERR_NAMESPACE_ALREADY_LAUNCHED))
+      ;; Less than 1 year must have passed since the namespace was "revealed"
+      (asserts!
+        (< block-height (+ (get revealed-at namespace-props) NAMESPACE_LAUNCHABILITY_TTL))
+        (err ERR_NAMESPACE_PREORDER_LAUNCHABILITY_EXPIRED))
+      ;; Mint the new name
+      (try! (mint-or-transfer-name? namespace name beneficiary))
+      ;; Update zonefile and props
+      (update-zonefile-and-props
+        namespace 
+        name  
+        none
+        (some block-height) ;; Set imported-at
+        none
+        zonefile-hash
+        "name-import")
+      (ok true)))
+
+;; NAMESPACE_READY
+;; The final step of the process launches the namespace and makes the namespace available to the public. Once a namespace
+;; is launched, anyone can register a name in it if they pay the appropriate amount of cryptocurrency.
+(define-public (namespace-ready (namespace (buff 20)))
+  (let (
+      (namespace-props (unwrap!
+        (map-get? namespaces namespace)
+        (err ERR_NAMESPACE_NOT_FOUND))))
+    ;; The sender principal must match the namespace's import principal
+    (asserts!
+      (is-eq (get namespace-import namespace-props) tx-sender)
+      (err ERR_NAMESPACE_OPERATION_UNAUTHORIZED))
+    ;; The name's namespace must not be launched
+    (asserts!
+      (is-none (get launched-at namespace-props))
+      (err ERR_NAMESPACE_ALREADY_LAUNCHED))
+    ;; Less than 1 year must have passed since the namespace was "revealed"
+    (asserts!
+      (< block-height (+ (get revealed-at namespace-props) NAMESPACE_LAUNCHABILITY_TTL))
+      (err ERR_NAMESPACE_PREORDER_LAUNCHABILITY_EXPIRED))        
+    (let ((namespace-props-updated (merge namespace-props { launched-at: (some block-height) })))
+      ;; The namespace will be set to "launched"
+      (map-set namespaces namespace namespace-props-updated)
+      ;; Emit an event
+      (print { namespace: namespace, status: "ready", properties: namespace-props-updated })
+      (ok true))))
+
+;; NAMESPACE_UPDATE_FUNCTION_PRICE
+(define-public (namespace-update-function-price (namespace (buff 20))
+                                        (p-func-base uint)
+                                        (p-func-coeff uint)
+                                        (p-func-b1 uint)
+                                        (p-func-b2 uint)
+                                        (p-func-b3 uint)
+                                        (p-func-b4 uint)
+                                        (p-func-b5 uint)
+                                        (p-func-b6 uint)
+                                        (p-func-b7 uint)
+                                        (p-func-b8 uint)
+                                        (p-func-b9 uint)
+                                        (p-func-b10 uint)
+                                        (p-func-b11 uint)
+                                        (p-func-b12 uint)
+                                        (p-func-b13 uint)
+                                        (p-func-b14 uint)
+                                        (p-func-b15 uint)
+                                        (p-func-b16 uint)
+                                        (p-func-non-alpha-discount uint)
+                                        (p-func-no-vowel-discount uint))
+  (let (
+      (namespace-props (unwrap!
+        (map-get? namespaces namespace)
+        (err ERR_NAMESPACE_NOT_FOUND)))
+      (price-function (tuple 
+        (buckets (list
+          p-func-b1
+          p-func-b2
+          p-func-b3
+          p-func-b4
+          p-func-b5
+          p-func-b6
+          p-func-b7
+          p-func-b8
+          p-func-b9
+          p-func-b10
+          p-func-b11
+          p-func-b12
+          p-func-b13
+          p-func-b14
+          p-func-b15
+          p-func-b16))
+        (base p-func-base)
+        (coeff p-func-coeff)
+        (nonalpha-discount p-func-non-alpha-discount)
+        (no-vowel-discount p-func-no-vowel-discount))))
+    ;; The sender principal must match the namespace's import principal
+    (asserts!
+      (is-eq (get namespace-import namespace-props) tx-sender)
+      (err ERR_NAMESPACE_OPERATION_UNAUTHORIZED))
+    ;; The namespace price function must still be editable
+    (asserts!
+      (get can-update-price-function namespace-props)
+      (err ERR_NAMESPACE_OPERATION_UNAUTHORIZED))
+    (map-set namespaces
+      namespace
+      (merge namespace-props { price-function: price-function }))
+    (ok true)))
+
+;; NAMESPACE_REVOKE_PRICE_EDITION
+(define-public (namespace-revoke-function-price-edition (namespace (buff 20)))
+  (let (
+      (namespace-props (unwrap!
+        (map-get? namespaces namespace)
+        (err ERR_NAMESPACE_NOT_FOUND))))
+    ;; The sender principal must match the namespace's import principal
+    (asserts!
+      (is-eq (get namespace-import namespace-props) tx-sender)
+      (err ERR_NAMESPACE_OPERATION_UNAUTHORIZED))
+    (map-set namespaces
+      namespace
+      (merge namespace-props { can-update-price-function: false }))
+    (ok true)))
+
+;; NAME_PREORDER
+;; This is the first transaction to be sent. It tells all BNS nodes the salted hash of the BNS name,
+;; and it burns the registration fee.
+(define-public (name-preorder (hashed-salted-fqn (buff 20))
+                              (stx-to-burn uint))
+  (let 
+    ((former-preorder 
+      (map-get? name-preorders { hashed-salted-fqn: hashed-salted-fqn, buyer: tx-sender })))
+    ;; Ensure eventual former pre-order expired 
+    (asserts! 
+      (if (is-none former-preorder)
+        true
+        (>= block-height (+ NAME_PREORDER_CLAIMABILITY_TTL
+                            (unwrap-panic (get created-at former-preorder)))))
+      (err ERR_NAME_PREORDER_ALREADY_EXISTS))
+          (asserts! (> stx-to-burn u0) (err ERR_NAMESPACE_STX_BURNT_INSUFFICIENT))    
+    ;; Ensure that the hashed fqn is 20 bytes long
+    (asserts! (is-eq (len hashed-salted-fqn) u20) (err ERR_NAME_HASH_MALFORMED))
+    ;; Ensure that user will be burning a positive amount of tokens
+    (asserts! (> stx-to-burn u0) (err ERR_NAME_STX_BURNT_INSUFFICIENT))
+    ;; Burn the tokens
+    (unwrap! (stx-burn? stx-to-burn tx-sender) (err ERR_INSUFFICIENT_FUNDS))
+    ;; Register the pre-order
+    (map-set name-preorders
+      { hashed-salted-fqn: hashed-salted-fqn, buyer: tx-sender }
+      { created-at: block-height, stx-burned: stx-to-burn, claimed: false })
+    (ok (+ block-height NAME_PREORDER_CLAIMABILITY_TTL))))
+
+;; NAME_REGISTRATION
+;; This is the second transaction to be sent. It reveals the salt and the name to all BNS nodes,
+;; and assigns the name an initial public key hash and zone file hash
+(define-public (name-register (namespace (buff 20))
+                              (name (buff 48))
+                              (salt (buff 20))
+                              (zonefile-hash (buff 20)))
+  (let (
+    (hashed-salted-fqn (hash160 (concat (concat (concat name 0x2e) namespace) salt)))
+    (namespace-props (unwrap!
+          (map-get? namespaces namespace)
+          (err ERR_NAMESPACE_NOT_FOUND)))
+    (preorder (unwrap!
+      (map-get? name-preorders { hashed-salted-fqn: hashed-salted-fqn, buyer: tx-sender })
+      (err ERR_NAME_PREORDER_NOT_FOUND))))
+      ;; The name can be registered
+      (asserts! (try! (can-name-be-registered namespace name))
+        (err ERR_NAME_UNAVAILABLE))
+      ;; The preorder must have been created after the launch of the namespace
+      (asserts!
+        (> (get created-at preorder) (unwrap-panic (get launched-at namespace-props)))
+        (err ERR_NAME_PREORDERED_BEFORE_NAMESPACE_LAUNCH))
+      ;; The preorder entry must be unclaimed
+      (asserts!
+        (is-eq (get claimed preorder) false)
+        (err ERR_NAME_ALREADY_CLAIMED))
+      ;; Less than 24 hours must have passed since the name was preordered
+      (asserts!
+        (< block-height (+ (get created-at preorder) NAME_PREORDER_CLAIMABILITY_TTL))
+        (err ERR_NAME_CLAIMABILITY_EXPIRED))
+      ;; The amount burnt must be equal to or greater than the cost of the name
+      (asserts!
+        (>= (get stx-burned preorder) (compute-name-price name (get price-function namespace-props)))
+        (err ERR_NAME_STX_BURNT_INSUFFICIENT))
+      ;; Mint the name if new, transfer the name otherwise.
+      (try! (mint-or-transfer-name? namespace name tx-sender))
+      ;; Update name's metadata / properties
+      (update-zonefile-and-props
+        namespace 
+        name
+        (some block-height)
+        none
+        none
+        zonefile-hash
+        "name-register")
+      (ok true)))
+
+;; NAME_UPDATE
+;; A NAME_UPDATE transaction changes the name's zone file hash. You would send one of these transactions 
+;; if you wanted to change the name's zone file contents. 
+;; For example, you would do this if you want to deploy your own Gaia hub and want other people to read from it.
+(define-public (name-update (namespace (buff 20))
+                            (name (buff 48))
+                            (zonefile-hash (buff 20)))
+  (let (
+    (data (try! (check-name-ops-preconditions namespace name))))
+    ;; Update the zonefile
+    (update-zonefile-and-props
+      namespace 
+      name  
+      (get registered-at (get name-props data))
+      (get imported-at (get name-props data))
+      none
+      zonefile-hash
+      "name-update")
+    (ok true)))
+
+;; NAME_TRANSFER
+;; A NAME_TRANSFER transaction changes the name's public key hash. You would send one of these transactions if you wanted to:
+;; - Change your private key
+;; - Send the name to someone else
+;; When transferring a name, you have the option to also clear the name's zone file hash (i.e. set it to null). 
+;; This is useful for when you send the name to someone else, so the recipient's name does not resolve to your zone file.
+(define-public (name-transfer (namespace (buff 20))
+                              (name (buff 48))
+                              (new-owner principal)
+                              (zonefile-hash (optional (buff 20))))
+  (let (
+    (data (try! (check-name-ops-preconditions namespace name)))
+    (can-new-owner-get-name (try! (can-receive-name new-owner))))
+    ;; The new owner does not own a name
+    (asserts!
+      can-new-owner-get-name
+      (err ERR_PRINCIPAL_ALREADY_ASSOCIATED))
+    ;; Transfer the name
+    (unwrap!
+      (update-name-ownership? namespace name tx-sender new-owner)
+      (err ERR_NAME_TRANSFER_FAILED))
+    ;; Update or clear the zonefile
+    (update-zonefile-and-props
+        namespace 
+        name  
+        (get registered-at (get name-props data))
+        (get imported-at (get name-props data))
+        none
+        (if (is-none zonefile-hash)
+          0x
+          (unwrap-panic zonefile-hash))
+        "name-transfer")
+    (ok true)))
+
+;; NAME_REVOKE
+;; A NAME_REVOKE transaction makes a name unresolvable. The BNS consensus rules stipulate that once a name 
+;; is revoked, no one can change its public key hash or its zone file hash. 
+;; The name's zone file hash is set to null to prevent it from resolving.
+;; You should only do this if your private key is compromised, or if you want to render your name unusable for whatever reason.
+(define-public (name-revoke (namespace (buff 20))
+                            (name (buff 48)))
+  (let (
+    (data (try! (check-name-ops-preconditions namespace name))))
+    ;; Clear the zonefile
+    (update-zonefile-and-props
+        namespace 
+        name  
+        (get registered-at (get name-props data))
+        (get imported-at (get name-props data))
+        (some block-height)
+        0x
+        "name-revoke")
+    (ok true)))
+
+;; NAME_RENEWAL
+;; Depending in the namespace rules, a name can expire. For example, names in the .id namespace expire after 2 years. 
+;; You need to send a NAME_RENEWAL every so often to keep your name.
+;; You will pay the registration cost of your name to the namespace's designated burn address when you renew it.
+;; When a name expires, it enters a month-long "grace period" (5000 blocks). 
+;; It will stop resolving in the grace period, and all of the above operations will cease to be honored by the BNS consensus rules.
+;; You may, however, send a NAME_RENEWAL during this grace period to preserve your name.
+;; If your name is in a namespace where names do not expire, then you never need to use this transaction.
+(define-public (name-renewal (namespace (buff 20))
+                             (name (buff 48))
+                             (stx-to-burn uint)
+                             (new-owner (optional principal))
+                             (zonefile-hash (optional (buff 20))))
+  (let (
+    (namespace-props (unwrap!
+      (map-get? namespaces namespace)
+      (err ERR_NAMESPACE_NOT_FOUND)))
+    (owner (unwrap!
+      (nft-get-owner? names { name: name, namespace: namespace })
+      (err ERR_NAME_NOT_FOUND))) ;; The name must exist
+    (name-props (unwrap!
+      (map-get? name-properties { name: name, namespace: namespace })
+      (err ERR_NAME_NOT_FOUND)))) ;; The name must exist
+    ;; The namespace must be launched
+    (asserts!
+      (is-some (get launched-at namespace-props))
+      (err ERR_NAMESPACE_NOT_LAUNCHED))
+    ;; The namespace should require renewals
+    (asserts!
+      (> (get lifetime namespace-props) u0)
+      (err ERR_NAME_OPERATION_UNAUTHORIZED))
+    ;; The sender must match the name's current owner
+    (asserts!
+      (is-eq owner tx-sender)
+      (err ERR_NAME_OPERATION_UNAUTHORIZED))
+    ;; If expired, the name must be in the renewal grace period.
+    (if (try! (is-name-lease-expired namespace name))
+      (asserts!
+        (is-eq (try! (is-name-in-grace-period namespace name)) true)
+        (err ERR_NAME_EXPIRED))
+      true)
+    ;; The amount burnt must be equal to or greater than the cost of the namespace
+    (asserts!
+      (>= stx-to-burn (compute-name-price name (get price-function namespace-props)))
+      (err ERR_NAME_STX_BURNT_INSUFFICIENT))
+    ;; The name must not be revoked
+    (asserts!
+      (is-none (get revoked-at name-props))
+      (err ERR_NAME_REVOKED))
+    ;; Transfer the name, if any new-owner
+    (if (is-none new-owner)
+      true 
+      (try! (can-receive-name (unwrap-panic new-owner))))
+    ;; Update the zonefile, if any.
+    (if (is-none zonefile-hash)
+      (map-set name-properties
+        { name: name, namespace: namespace }
+        { registered-at: (some block-height),
+          imported-at: none,
+          revoked-at: none,
+          zonefile-hash: (get zonefile-hash name-props) })
+      (update-zonefile-and-props
+              namespace 
+              name
+              (some block-height)
+              none
+              none
+              (unwrap-panic zonefile-hash)
+              "name-renewal"))  
+    (ok true)))
+
+;; Additionals public methods
+
+(define-read-only (get-namespace-price (namespace (buff 20)))
+  (let ((namespace-len (len namespace)))
+    (asserts!
+      (> namespace-len u0)
+      (err ERR_NAMESPACE_BLANK))
+    (ok (unwrap-panic
+      (element-at NAMESPACE_PRICE_TIERS (min u7 (- namespace-len u1)))))))
+
+(define-read-only (get-name-price (namespace (buff 20)) (name (buff 48)))
+  (let (
+      (namespace-props (unwrap!
+        (map-get? namespaces namespace)
+        (err ERR_NAMESPACE_NOT_FOUND))))
+    (ok (compute-name-price name (get price-function namespace-props)))))
+
+(define-read-only (check-name-ops-preconditions (namespace (buff 20)) (name (buff 48)))
+  (let (
+    (owner (unwrap!
+      (nft-get-owner? names { name: name, namespace: namespace })
+      (err ERR_NAME_NOT_FOUND))) ;; The name must exist
+    (namespace-props (unwrap!
+      (map-get? namespaces namespace)
+      (err ERR_NAMESPACE_NOT_FOUND)))
+    (name-props (unwrap!
+      (map-get? name-properties { name: name, namespace: namespace })
+      (err ERR_NAME_NOT_FOUND)))) ;; The name must exist
+      ;; The namespace must be launched
+      (asserts!
+        (is-some (get launched-at namespace-props))
+        (err ERR_NAMESPACE_NOT_LAUNCHED))
+      ;; The sender must match the name's current owner
+      (asserts!
+        (is-eq owner tx-sender)
+        (err ERR_NAME_OPERATION_UNAUTHORIZED))
+      ;; The name must not be in the renewal grace period
+      (asserts!
+        (is-eq (try! (is-name-in-grace-period namespace name)) false)
+        (err ERR_NAME_GRACE_PERIOD))
+      ;; The name must not be expired
+      (asserts!
+        (is-eq (try! (is-name-lease-expired namespace name)) false)
+        (err ERR_NAME_EXPIRED))
+      ;; The name must not be revoked
+      (asserts!
+        (is-none (get revoked-at name-props))
+        (err ERR_NAME_REVOKED))
+      (ok { namespace-props: namespace-props, name-props: name-props, owner: owner })))
+
+(define-read-only (can-namespace-be-registered (namespace (buff 20)))
+  (ok (is-namespace-available namespace)))
+
+(define-read-only (is-name-lease-expired (namespace (buff 20)) (name (buff 48)))
+  (let (
+    (namespace-props (unwrap! 
+      (map-get? namespaces namespace) 
+      (err ERR_NAMESPACE_NOT_FOUND)))
+    (name-props (unwrap! 
+      (map-get? name-properties { name: name, namespace: namespace }) 
+      (err ERR_NAME_NOT_FOUND)))
+    (lease-started-at (try! (name-lease-started-at? (get launched-at namespace-props) (get revealed-at namespace-props) name-props)))
+    (lifetime (get lifetime namespace-props)))
+      (if (is-eq lifetime u0)
+        (ok false)
+        (ok (> block-height (+ lifetime lease-started-at))))))
+
+(define-read-only (is-name-in-grace-period (namespace (buff 20)) (name (buff 48)))
+  (let (
+    (namespace-props (unwrap! 
+      (map-get? namespaces namespace) 
+      (err ERR_NAMESPACE_NOT_FOUND)))
+    (name-props (unwrap! 
+      (map-get? name-properties { name: name, namespace: namespace }) 
+      (err ERR_NAME_NOT_FOUND)))
+    (lease-started-at (try! (name-lease-started-at? (get launched-at namespace-props) (get revealed-at namespace-props) name-props)))
+    (lifetime (get lifetime namespace-props)))
+      (if (is-eq lifetime u0)
+        (ok false)
+        (ok (and 
+          (> block-height (+ lifetime lease-started-at)) 
+          (<= block-height (+ (+ lifetime lease-started-at) NAME_GRACE_PERIOD_DURATION)))))))
+
+(define-read-only (resolve-principal (owner principal))
+  (match (map-get? owner-name owner)
+    name (match (name-resolve (get namespace name) (get name name))
+      resolved-name (ok name)
+      error (err {code: error, name: (some name)}))
+    (err {code: ERR_NAME_NOT_FOUND, name: none})))
+
+(define-read-only (can-receive-name (owner principal))
+  (let ((current-owned-name (map-get? owner-name owner)))
+    (if (is-none current-owned-name)
+      (ok true)
+      (let (
+        (namespace (unwrap-panic (get namespace current-owned-name)))
+        (name (unwrap-panic (get name current-owned-name))))
+        (if (is-namespace-available namespace)
+          (ok true)
+          (begin
+            ;; Early return if lease is expired
+            (asserts! 
+              (not (try! (is-name-lease-expired namespace name)))
+              (ok true))
+            (let (
+              (name-props (unwrap-panic (map-get? name-properties { name: name, namespace: namespace }))))
+              ;; Has name been revoked?
+              (asserts! (is-some (get revoked-at name-props)) (ok false))
+              (ok true))))))))
+
+(define-read-only (can-name-be-registered (namespace (buff 20)) (name (buff 48)))
+  (let (
+      (wrapped-name-props (map-get? name-properties { name: name, namespace: namespace }))
+      (namespace-props (unwrap! (map-get? namespaces namespace) (ok false))))
+    ;; The name must only have valid chars
+    (asserts!
+      (not (has-invalid-chars name))
+      (err ERR_NAME_CHARSET_INVALID))
+    ;; Ensure that namespace has been launched 
+    (unwrap! (get launched-at namespace-props) (ok false))
+    ;; Early return - Name has never be minted
+    (asserts! (is-some (nft-get-owner? names { name: name, namespace: namespace })) (ok true))
+    (let ((name-props (unwrap-panic wrapped-name-props)))
+      ;; Integrity check - Ensure that the name was either "imported" or "registered".
+      (asserts! (is-eq (xor 
+        (match (get registered-at name-props) res 1 0)
+        (match (get imported-at name-props)   res 1 0)) 1) (err ERR_PANIC))
+      ;; Is lease expired?
+      (is-name-lease-expired namespace name))))
+
+(define-read-only (name-resolve (namespace (buff 20)) (name (buff 48)))
+  (let (
+    (owner (unwrap!
+      (nft-get-owner? names { name: name, namespace: namespace })
+      (err ERR_NAME_NOT_FOUND))) ;; The name must exist
+    (name-props (unwrap!
+      (map-get? name-properties { name: name, namespace: namespace })
+      (err ERR_NAME_NOT_FOUND)))
+    (namespace-props (unwrap! 
+      (map-get? namespaces namespace) 
+      (err ERR_NAMESPACE_NOT_FOUND))))
+    ;; The name must not be in grace period
+    (asserts!
+      (not (try! (is-name-in-grace-period namespace name)))
+      (err ERR_NAME_GRACE_PERIOD))
+    ;; The name must not be expired
+    (asserts! 
+      (not (try! (is-name-lease-expired namespace name)))
+      (err ERR_NAME_EXPIRED))
+    ;; The name must not be revoked
+    (asserts!
+      (is-none (get revoked-at name-props))
+      (err ERR_NAME_REVOKED))
+    ;; Get the zonefile
+    (let (
+      (lease-started-at (try! (name-lease-started-at? (get launched-at namespace-props) (get revealed-at namespace-props) name-props))))
+      (ok { 
+        zonefile-hash: (get zonefile-hash name-props), 
+        owner: owner,
+        lease-started-at: lease-started-at,
+        lease-ending-at: (if (is-eq (get lifetime namespace-props) u0) none (some (+ lease-started-at (get lifetime namespace-props))))
+      }))))
+
+(define-read-only (get-namespace-properties (namespace (buff 20)))
+  (let (
+    (namespace-props (unwrap!
+      (map-get? namespaces namespace)
+      (err ERR_NAMESPACE_NOT_FOUND))))
+    (ok { namespace: namespace, properties: namespace-props })))

--- a/bns-v2/contracts/external/crypto.clar
+++ b/bns-v2/contracts/external/crypto.clar
@@ -1,0 +1,2 @@
+(define-read-only (crypto-hash160 (value (buff 10000)))
+    (hash160 value))

--- a/bns-v2/contracts/sell-bns.clar
+++ b/bns-v2/contracts/sell-bns.clar
@@ -1,0 +1,32 @@
+(define-constant bns-name {namespace: 0x627363, name: 0x3232})
+(define-data-var name-owner tx-sender)
+(define-data-var requested-amount-in-ustx uint 100)
+(define-data-var namespace 0x627363)
+
+;; transfer to escrow
+(contract-call? 'SP000000000000000000002Q6VF78.bns name-transfer (get namespace bns-name) (get name bns-name) 
+    tx-sender (as-contract tx-sender))
+    
+(define-public (buy (amount-in-ustx uint))
+    (let ((buyer tx-sender))
+        (asserts! (is-eq amount-in-ustx (var-get requested-amount-in-ustx)) err-offer-mismatch)
+        (asserts! (is-eq name-owner (get-current-name-owner)) err-not-authorized)
+        (try! (stx-transfer? amount-in-ustx buyer name-owner))
+        (try! (as-contract (contract-call? 'SP000000000000000000002Q6VF78.bns name-transfer (get namespace bns-name) (get name bns-name)  
+                    tx-sender buyer)))
+        (ok true)))
+
+;; succeeds only if name is in escrow
+(define-public (set-price (amount-in-ustx uint))
+    (begin
+        (asserts! (is-eq tx-sender (var-get name-owner)) err-not-authorized)
+        (var-set requested-amount-in-ustx amount-in-ustx)
+        (contract-call? 'SP000000000000000000002Q6VF78.bns resolve-principal (as-contract tx-sender))))
+
+;;
+(define-public (new-offer (amount-in-ustx uint))
+    (match (contract-call? 'SP000000000000000000002Q6VF78.bns resolve-principal tx-sender)
+        name
+    (contract-call? 'SP000000000000000000002Q6VF78.bns name-transfer  
+    tx-sender (as-contract tx-sender))
+)

--- a/bns-v2/contracts/sell-bns.clar
+++ b/bns-v2/contracts/sell-bns.clar
@@ -1,32 +1,37 @@
-(define-constant bns-name {namespace: 0x627363, name: 0x3232})
-(define-data-var name-owner tx-sender)
-(define-data-var requested-amount-in-ustx uint 100)
-(define-data-var namespace 0x627363)
+;; (define-constant bns-name (unwrap-panic (contract-call? 'SP000000000000000000002Q6VF78.bns resolve-principal tx-sender))
+(define-constant bns-name {namespace: 0x67676767676767676767, name: 0x303132})
+(define-constant name-owner tx-sender)
+(define-data-var requested-amount-in-ustx uint u1000000000)
 
 ;; transfer to escrow
-(contract-call? 'SP000000000000000000002Q6VF78.bns name-transfer (get namespace bns-name) (get name bns-name) 
-    tx-sender (as-contract tx-sender))
+(print (contract-call? 'SP000000000000000000002Q6VF78.bns name-transfer (get namespace bns-name) (get name bns-name) 
+    (as-contract tx-sender) none))
+
     
-(define-public (buy (amount-in-ustx uint))
+(define-public (buy (amount-in-ustx uint) (zonefile-hash (optional (buff 20))))
     (let ((buyer tx-sender))
-        (asserts! (is-eq amount-in-ustx (var-get requested-amount-in-ustx)) err-offer-mismatch)
-        (asserts! (is-eq name-owner (get-current-name-owner)) err-not-authorized)
+        (asserts! (is-eq amount-in-ustx (var-get requested-amount-in-ustx)) (err u500))
         (try! (stx-transfer? amount-in-ustx buyer name-owner))
-        (try! (as-contract (contract-call? 'SP000000000000000000002Q6VF78.bns name-transfer (get namespace bns-name) (get name bns-name)  
-                    tx-sender buyer)))
+        (try! (to-bool-response (as-contract (contract-call? 'SP000000000000000000002Q6VF78.bns name-transfer (get namespace bns-name) (get name bns-name)  
+                 buyer zonefile-hash))))
         (ok true)))
 
 ;; succeeds only if name is in escrow
 (define-public (set-price (amount-in-ustx uint))
     (begin
-        (asserts! (is-eq tx-sender (var-get name-owner)) err-not-authorized)
+        (asserts! (is-eq tx-sender name-owner) (err {code: 403, name: none}))
         (var-set requested-amount-in-ustx amount-in-ustx)
         (contract-call? 'SP000000000000000000002Q6VF78.bns resolve-principal (as-contract tx-sender))))
 
-;;
-(define-public (new-offer (amount-in-ustx uint))
-    (match (contract-call? 'SP000000000000000000002Q6VF78.bns resolve-principal tx-sender)
-        name
-    (contract-call? 'SP000000000000000000002Q6VF78.bns name-transfer  
-    tx-sender (as-contract tx-sender))
-)
+(define-public (cancel (zonefile-hash (optional (buff 20))))
+    (as-contract (contract-call? 'SP000000000000000000002Q6VF78.bns name-transfer (get namespace bns-name) (get name bns-name)  
+                 name-owner zonefile-hash)))
+
+
+
+;; convert response to standard bool response with uint error
+;; (response bool int) (response bool uint)
+(define-private (to-bool-response (value (response bool int)))
+    (match value
+           success (ok success)
+           error (err (to-uint error))))

--- a/bns-v2/settings/Devnet.toml
+++ b/bns-v2/settings/Devnet.toml
@@ -1,0 +1,138 @@
+[network]
+name = "devnet"
+deployment_fee_rate = 10
+
+[accounts.deployer]
+mnemonic = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw"
+balance = 100_000_000_000_000
+# secret_key: 753b7cc01a1a2e86221266a154af739463fce51219d97e4f856cd7200c3bd2a601
+# stx_address: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+# btc_address: mqVnk6NPRdhntvfm4hh9vvjiRkFDUuSYsH
+
+[accounts.wallet_1]
+mnemonic = "sell invite acquire kitten bamboo drastic jelly vivid peace spawn twice guilt pave pen trash pretty park cube fragile unaware remain midnight betray rebuild"
+balance = 100_000_000_000_000
+# secret_key: 7287ba251d44a4d3fd9276c88ce34c5c52a038955511cccaf77e61068649c17801
+# stx_address: ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5
+# btc_address: mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC
+
+[accounts.wallet_2]
+mnemonic = "hold excess usual excess ring elephant install account glad dry fragile donkey gaze humble truck breeze nation gasp vacuum limb head keep delay hospital"
+balance = 100_000_000_000_000
+# secret_key: 530d9f61984c888536871c6573073bdfc0058896dc1adfe9a6a10dfacadc209101
+# stx_address: ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG
+# btc_address: muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG
+
+[accounts.wallet_3]
+mnemonic = "cycle puppy glare enroll cost improve round trend wrist mushroom scorpion tower claim oppose clever elephant dinosaur eight problem before frozen dune wagon high"
+balance = 100_000_000_000_000
+# secret_key: d655b2523bcd65e34889725c73064feb17ceb796831c0e111ba1a552b0f31b3901
+# stx_address: ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC
+# btc_address: mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7
+
+[accounts.wallet_4]
+mnemonic = "board list obtain sugar hour worth raven scout denial thunder horse logic fury scorpion fold genuine phrase wealth news aim below celery when cabin"
+balance = 100_000_000_000_000
+# secret_key: f9d7206a47f14d2870c163ebab4bf3e70d18f5d14ce1031f3902fbbc894fe4c701
+# stx_address: ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND
+# btc_address: mg1C76bNTutiCDV3t9nWhZs3Dc8LzUufj8
+
+[accounts.wallet_5]
+mnemonic = "hurry aunt blame peanut heavy update captain human rice crime juice adult scale device promote vast project quiz unit note reform update climb purchase"
+balance = 100_000_000_000_000
+# secret_key: 3eccc5dac8056590432db6a35d52b9896876a3d5cbdea53b72400bc9c2099fe801
+# stx_address: ST2REHHS5J3CERCRBEPMGH7921Q6PYKAADT7JP2VB
+# btc_address: mweN5WVqadScHdA81aATSdcVr4B6dNokqx
+
+[accounts.wallet_6]
+mnemonic = "area desk dutch sign gold cricket dawn toward giggle vibrant indoor bench warfare wagon number tiny universe sand talk dilemma pottery bone trap buddy"
+balance = 100_000_000_000_000
+# secret_key: 7036b29cb5e235e5fd9b09ae3e8eec4404e44906814d5d01cbca968a60ed4bfb01
+# stx_address: ST3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ10MGCS0
+# btc_address: mzxXgV6e4BZSsz8zVHm3TmqbECt7mbuErt
+
+[accounts.wallet_7]
+mnemonic = "prevent gallery kind limb income control noise together echo rival record wedding sense uncover school version force bleak nuclear include danger skirt enact arrow"
+balance = 100_000_000_000_000
+# secret_key: b463f0df6c05d2f156393eee73f8016c5372caa0e9e29a901bb7171d90dc4f1401
+# stx_address: ST3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXEP8YGKJ
+# btc_address: n37mwmru2oaVosgfuvzBwgV2ysCQRrLko7
+
+[accounts.wallet_8]
+mnemonic = "female adjust gallery certain visit token during great side clown fitness like hurt clip knife warm bench start reunion globe detail dream depend fortune"
+balance = 100_000_000_000_000
+# secret_key: 6a1a754ba863d7bab14adbbc3f8ebb090af9e871ace621d3e5ab634e1422885e01
+# stx_address: ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP
+# btc_address: n2v875jbJ4RjBnTjgbfikDfnwsDV5iUByw
+
+[accounts.faucet]
+mnemonic = "shadow private easily thought say logic fault paddle word top book during ignore notable orange flight clock image wealth health outside kitten belt reform"
+balance = 100_000_000_000_000
+# secret_key: de433bdfa14ec43aa1098d5be594c8ffb20a31485ff9de2923b2689471c401b801
+# stx_address: STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6
+# btc_address: mjSrB3wS4xab3kYqFktwBzfTdPg367ZJ2d
+
+[devnet]
+disable_stacks_explorer = false
+disable_stacks_api = false
+# disable_bitcoin_explorer = true
+# working_dir = "tmp/devnet"
+# stacks_node_events_observers = ["host.docker.internal:8002"]
+# miner_mnemonic = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw"
+# miner_derivation_path = "m/44'/5757'/0'/0/0"
+# faucet_mnemonic = "shadow private easily thought say logic fault paddle word top book during ignore notable orange flight clock image wealth health outside kitten belt reform"
+# faucet_derivation_path = "m/44'/5757'/0'/0/0"
+# orchestrator_port = 20445
+# bitcoin_node_p2p_port = 18444
+# bitcoin_node_rpc_port = 18443
+# bitcoin_node_username = "devnet"
+# bitcoin_node_password = "devnet"
+# bitcoin_controller_block_time = 30_000
+# stacks_node_rpc_port = 20443
+# stacks_node_p2p_port = 20444
+# stacks_api_port = 3999
+# stacks_api_events_port = 3700
+# bitcoin_explorer_port = 8001
+# stacks_explorer_port = 8000
+# postgres_port = 5432
+# postgres_username = "postgres"
+# postgres_password = "postgres"
+# postgres_database = "postgres"
+# bitcoin_node_image_url = "quay.io/hirosystems/bitcoind:devnet-v2"
+# stacks_node_image_url = "localhost:5000/stacks-node:devnet-v2"
+# stacks_api_image_url = "hirosystems/stacks-blockchain-api:latest"
+# stacks_explorer_image_url = "hirosystems/explorer:latest"
+# bitcoin_explorer_image_url = "quay.io/hirosystems/bitcoin-explorer:devnet"
+# postgres_image_url = "postgres:alpine"
+# enable_hyperchain_node = true
+# hyperchain_node_image_url = "hirosystems/hyperchains:0.0.4-stretch"
+# hyperchain_leader_mnemonic = "female adjust gallery certain visit token during great side clown fitness like hurt clip knife warm bench start reunion globe detail dream depend fortune"
+# hyperchain_leader_derivation_path = "m/44'/5757'/0'/0/0"
+# hyperchain_contract_id = "STXMJXCJDCT4WPF2X1HE42T6ZCCK3TPMBRZ51JEG.hc-alpha"
+# hyperchain_node_rpc_port = 30443
+# hyperchain_node_p2p_port = 30444
+# hyperchain_events_ingestion_port = 30445
+# hyperchain_node_events_observers = ["host.docker.internal:8002"]
+
+
+# Send some stacking orders
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 3
+duration = 12
+wallet = "wallet_1"
+slots = 2
+btc_address = "mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC"
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 3
+duration = 12
+wallet = "wallet_2"
+slots = 1
+btc_address = "muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG"
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 3
+duration = 12
+wallet = "wallet_3"
+slots = 1
+btc_address = "mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7"

--- a/bns-v2/tests/deps.ts
+++ b/bns-v2/tests/deps.ts
@@ -1,0 +1,22 @@
+export type {
+  Account,
+  ReadOnlyFn,
+} from "https://deno.land/x/clarinet@v0.31.1/index.ts";
+
+export {
+  Clarinet,
+  Chain,
+  Tx,
+  types,
+} from "https://deno.land/x/clarinet@v0.31.1/index.ts";
+
+export {
+  assertEquals,
+  assertObjectMatch,
+} from "https://deno.land/std@0.125.0/testing/asserts.ts";
+
+export {
+  beforeEach,
+  describe,
+  it,
+} from "https://deno.land/x/test_suite@0.9.5/mod.ts";

--- a/bns-v2/tests/sell-bns_test.ts
+++ b/bns-v2/tests/sell-bns_test.ts
@@ -1,0 +1,23 @@
+import { Clarinet, Tx, Chain, Account, types, assertEquals } from "./deps.ts";
+import { setupNamespace } from "./utils.ts";
+
+Clarinet.test({
+  name: "Ensure that users can register approved names",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    const deployer = accounts.get("deployer")!.address;
+    setupNamespace(chain, deployer);
+
+    let block = chain.mineBlock([
+      Tx.contractCall(
+        "SP000000000000000000002Q6VF78.bns",
+        "name-transfer",
+        ["0x67676767676767676767", "0x303132","'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.sell-bns", "none"],
+        deployer
+      ),
+      Tx.contractCall("sell-bns", "cancel", ["none"], deployer),
+    ]);
+
+    block.receipts[0].result.expectOk();
+    console.log(block.receipts[1].events);
+  },
+});

--- a/bns-v2/tests/utils.ts
+++ b/bns-v2/tests/utils.ts
@@ -1,0 +1,99 @@
+import { Tx, Chain, types, assertEquals } from "./deps.ts";
+
+export function setupNamespace(chain: Chain, deployer: string) {
+  const hashResponse = chain.callReadOnlyFn(
+    "crypto",
+    "crypto-hash160",
+    ["0x6767676767676767676700"], // namespace + salt 0x00
+    deployer
+  );
+
+  const hashResponseName = chain.callReadOnlyFn(
+    "crypto",
+    "crypto-hash160",
+    ["0x3031322e6767676767676767676700"], // name + . + namespace + salt 0x00
+    deployer
+  );
+
+  let block = chain.mineBlock([
+    Tx.contractCall(
+      "SP000000000000000000002Q6VF78.bns",
+      "namespace-preorder",
+      [hashResponse.result, types.uint(640_000_000)],
+      deployer
+    ),
+    Tx.contractCall(
+      "SP000000000000000000002Q6VF78.bns",
+      "namespace-reveal",
+      [
+        "0x67676767676767676767",
+        "0x00",
+        types.uint(0),
+        types.uint(0),
+        types.uint(0),
+        types.uint(0),
+        types.uint(0),
+        types.uint(0),
+        types.uint(0),
+        types.uint(0),
+        types.uint(0),
+        types.uint(0),
+        types.uint(0),
+        types.uint(0),
+        types.uint(0),
+        types.uint(0),
+        types.uint(0),
+        types.uint(0),
+        types.uint(0),
+        types.uint(0),
+        types.uint(0),
+        types.uint(1),
+        types.uint(50000),
+        types.principal(deployer),
+      ],
+      deployer
+    ),
+    Tx.contractCall(
+      "SP000000000000000000002Q6VF78.bns",
+      "namespace-ready",
+      ["0x67676767676767676767"],
+      deployer
+    ),
+  ]);
+  block.receipts[0].result.expectOk();
+  block.receipts[1].result.expectOk();
+  block.receipts[2].result.expectOk();
+
+  chain.mineEmptyBlock(1);
+  block = chain.mineBlock([
+    Tx.contractCall(
+      "SP000000000000000000002Q6VF78.bns",
+      "get-namespace-properties",
+      ["0x67676767676767676767"],
+      deployer
+    ),
+    Tx.contractCall(
+      "SP000000000000000000002Q6VF78.bns",
+      "can-name-be-registered",
+      ["0x67676767676767676767", "0x303132"],
+      deployer
+    ),
+
+    Tx.contractCall(
+      "SP000000000000000000002Q6VF78.bns",
+      "name-preorder",
+      [hashResponseName.result, types.uint(640_000_000)],
+      deployer
+    ),
+    Tx.contractCall(
+      "SP000000000000000000002Q6VF78.bns",
+      "name-register",
+      ["0x67676767676767676767", "0x303132", "0x00", "0x"],
+      deployer
+    ),
+  ]);
+  block.receipts[0].result.expectOk();
+  block.receipts[1].result.expectOk().expectBool(true);
+  block.receipts[2].result.expectOk();
+  block.receipts[3].result.expectOk();
+}

--- a/frontend-dev/src/components/preorder-name-button.tsx
+++ b/frontend-dev/src/components/preorder-name-button.tsx
@@ -1,4 +1,4 @@
-import { bufferCV, bufferCVFromString, ClarityValue, tupleCV } from 'micro-stacks/clarity';
+import { bufferCV, bufferCVFromString, ClarityValue, noneCV, tupleCV } from 'micro-stacks/clarity';
 import { useOpenContractCall } from '@micro-stacks/react';
 import {
   createAssetInfo,
@@ -32,7 +32,7 @@ export const PreorderNameButton = ({
   const contractAddress = contract.address;
   const contractName = contract.name;
   const functionName = 'name-preorder';
-  const functionArgs: ClarityValue[] = [bufferCV(hashedSaltedName)];
+  const functionArgs: ClarityValue[] = [bufferCV(hashedSaltedName), noneCV()];
 
   const postConditions: PostCondition[] = [
     makeStandardSTXPostCondition(stxAddress, FungibleConditionCode.LessEqual, 10_000_000),


### PR DESCRIPTION
This PR collects all changes for v2
* **Add optional buyer during preorder**. Users can now provide an address that should receive the name. In v1, this was always the tx-sender.
* **Prevent double redeem**. Now, fees from expired preorders can only claimed once. In v1, it was possible to claim the fees as often as you want. 