### PR TITLE
Controller with recipient

### DIFF
--- a/backend-public/contracts/support-preorder.clar
+++ b/backend-public/contracts/support-preorder.clar
@@ -2,7 +2,7 @@
 (define-public (claim-preorder (old-hashed-salted-fqn (buff 20)) (hashed-salted-fqn (buff 20)) (owner principal) (new-owner principal))
   (begin
     (try! (contract-call? .ryder-handles-controller claim-fees old-hashed-salted-fqn owner))
-    (contract-call? .ryder-handles-controller name-preorder hashed-salted-fqn)))
+    (contract-call? .ryder-handles-controller name-preorder hashed-salted-fqn (some new-owner))))
 
 ;; register the preordered name and transfer to the new owner
 (define-public (register-transfer (namespace (buff 20))

--- a/backend-public/tests/ryder-handles-controller_test.ts
+++ b/backend-public/tests/ryder-handles-controller_test.ts
@@ -55,7 +55,7 @@ Clarinet.test({
       Tx.contractCall(
         "ryder-handles-controller",
         "name-preorder",
-        [hashResponse1.result],
+        [hashResponse1.result, types.none()],
         account1
       ),
       Tx.contractCall(
@@ -74,7 +74,7 @@ Clarinet.test({
       Tx.contractCall(
         "ryder-handles-controller",
         "name-preorder",
-        [hashResponse2.result],
+        [hashResponse2.result, types.none()],
         account2
       ),
       Tx.contractCall(
@@ -167,7 +167,7 @@ Clarinet.test({
       Tx.contractCall(
         "ryder-handles-controller",
         "name-preorder",
-        [hashResponse1.result],
+        [hashResponse1.result, types.none()],
         account1
       ),
       Tx.contractCall(
@@ -258,7 +258,7 @@ Clarinet.test({
       Tx.contractCall(
         "ryder-handles-controller",
         "name-preorder",
-        [hashResponse1.result],
+        [hashResponse1.result, types.none()],
         account1
       ),
     ]);
@@ -294,6 +294,18 @@ Clarinet.test({
 
     block.receipts[0].result.expectErr().expectUint(503); // too early
 
+    // try to claim fees using a different key
+    block = chain.mineBlock([
+      Tx.contractCall(
+        "ryder-handles-controller",
+        "claim-fees",
+        [hashResponse1.result, types.principal(account2)],
+        account2
+      ),
+    ]);
+
+    block.receipts[0].result.expectErr().expectUint(404);
+
     // claim fees
     block = chain.mineBlock([
       Tx.contractCall(
@@ -311,6 +323,18 @@ Clarinet.test({
       `${deployer}.ryder-handles-controller`,
       deployer
     );
+
+    // try to claim fees again
+    block = chain.mineBlock([
+      Tx.contractCall(
+        "ryder-handles-controller",
+        "claim-fees",
+        [hashResponse1.result, types.principal(account1)],
+        account2
+      ),
+    ]);
+
+    block.receipts[0].result.expectErr().expectUint(502); // err-invalid-claim
   },
 });
 
@@ -353,7 +377,7 @@ Clarinet.test({
       Tx.contractCall(
         "ryder-handles-controller",
         "name-preorder",
-        [hashResponse1.result],
+        [hashResponse1.result, types.none()],
         account1
       ),
       Tx.contractCall(

--- a/backend-public/tests/ryder-handles-controller_test.ts
+++ b/backend-public/tests/ryder-handles-controller_test.ts
@@ -1,6 +1,31 @@
 import { Clarinet, Tx, Chain, Account, types } from "./deps.ts";
 import { setupNamespace, setupNamespace2 } from "./utils.ts";
 
+const setupNamespaceController = (chain: Chain, deployer: string) => {
+  let block = chain.mineBlock([
+    Tx.contractCall(
+      "community-handles",
+      "set-namespace-controller",
+      ["0x67676767676767676767", `'${deployer}.ryder-handles-controller`],
+      deployer
+    ),
+  ]);
+
+  block.receipts[0].result.expectOk().expectBool(true);
+};
+
+const setupNamespaceController2 = (chain: Chain, deployer: string) => {
+  let block = chain.mineBlock([
+    Tx.contractCall(
+      "community-handles",
+      "set-namespace-controller",
+      ["0x68686868686868686868", `'${deployer}.ryder-handles-controller`],
+      deployer
+    ),
+  ]);
+  block.receipts[0].result.expectOk().expectBool(true);
+};
+
 Clarinet.test({
   name: "Ensure that users can register approved names",
   async fn(chain: Chain, accounts: Map<string, Account>) {
@@ -11,23 +36,8 @@ Clarinet.test({
     setupNamespace2(chain, deployer);
     setupNamespace(chain, deployer);
 
-    let block = chain.mineBlock([
-      Tx.contractCall(
-        "community-handles",
-        "set-namespace-controller",
-        ["0x67676767676767676767", `'${deployer}.ryder-handles-controller`],
-        deployer
-      ),
-      Tx.contractCall(
-        "community-handles",
-        "set-namespace-controller",
-        ["0x68686868686868686868", `'${deployer}.ryder-handles-controller`],
-        deployer
-      ),
-    ]);
-
-    block.receipts[0].result.expectOk().expectBool(true);
-    block.receipts[1].result.expectOk().expectBool(true);
+    setupNamespaceController(chain, deployer);
+    setupNamespaceController2(chain, deployer);
 
     const hashResponse1 = chain.callReadOnlyFn(
       "crypto",
@@ -43,7 +53,7 @@ Clarinet.test({
       deployer
     );
 
-    block = chain.mineBlock([
+    let block = chain.mineBlock([
       Tx.contractCall(
         "ryder-handles-controller",
         "set-approval-pubkey",
@@ -69,7 +79,7 @@ Clarinet.test({
           types.principal(account1),
           "0x01020304",
         ],
-        account1
+        account1 // called by name buyer
       ),
       Tx.contractCall(
         "ryder-handles-controller",
@@ -88,13 +98,13 @@ Clarinet.test({
           types.principal(account2),
           "0x01020304",
         ],
-        deployer
+        deployer // called by different user
       ),
     ]);
 
     block.receipts[0].result.expectOk().expectBool(true);
     // preorder and register a name
-    block.receipts[1].result.expectOk().expectUint(148);
+    block.receipts[1].result.expectOk().expectUint(149);
     block.receipts[2].result.expectOk().expectBool(true);
 
     // fees are sent to controller-admin and escrow on preorder
@@ -117,8 +127,111 @@ Clarinet.test({
     );
 
     // preorder and register a second name
-    block.receipts[3].result.expectOk().expectUint(148);
+    block.receipts[3].result.expectOk().expectUint(149);
     block.receipts[4].result.expectOk().expectBool(true);
+  },
+});
+
+
+
+Clarinet.test({
+  name: "Ensure that users can preorder and register names for other users",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    const deployer = accounts.get("deployer")!.address;
+    const account1 = accounts.get("wallet_1")!.address;
+    const account2 = accounts.get("wallet_2")!.address;
+
+    setupNamespace2(chain, deployer);
+    setupNamespace(chain, deployer);
+
+    setupNamespaceController(chain, deployer);
+    setupNamespaceController2(chain, deployer);
+
+    const hashResponse1 = chain.callReadOnlyFn(
+      "crypto",
+      "crypto-hash160",
+      ["0x31312e6767676767676767676700"],
+      deployer
+    );
+
+    const hashResponse2 = chain.callReadOnlyFn(
+      "crypto",
+      "crypto-hash160",
+      ["0x32322e6767676767676767676700"],
+      deployer
+    );
+
+    let block = chain.mineBlock([
+      Tx.contractCall(
+        "ryder-handles-controller",
+        "set-approval-pubkey",
+        [
+          "0x02a3b986401a619013ee1deee0ccba58a5b2235260d55259106e5fc9c53e6a9d71",
+        ],
+        deployer
+      ),
+      Tx.contractCall(
+        "ryder-handles-controller",
+        "name-preorder",
+        [hashResponse1.result, types.some(types.principal(account2))],
+        account1
+      ),
+      // try with wrong name buyer
+      Tx.contractCall(
+        "ryder-handles-controller",
+        "name-register",
+        [
+          "0x67676767676767676767",
+          "0x3131",
+          "0x00",
+          "0xd693e8d1d558a5aabff258de2bd5ec6da5eea52ec9b45e4c2c9f34aa547cabb3235ad7223adf3a8d4e51f3cd7fbefdc001fcee9d3e8ddda4643c42dcea07bb6700",
+          types.principal(account1),
+          "0x01020304",
+        ],
+        account1
+      ),
+      // register name with provided buyer
+      Tx.contractCall(
+        "ryder-handles-controller",
+        "name-register",
+        [
+          "0x67676767676767676767",
+          "0x3131",
+          "0x00",
+          "0xd693e8d1d558a5aabff258de2bd5ec6da5eea52ec9b45e4c2c9f34aa547cabb3235ad7223adf3a8d4e51f3cd7fbefdc001fcee9d3e8ddda4643c42dcea07bb6700",
+          types.principal(account2),
+          "0x01020304",
+        ],
+        deployer
+      ),
+    ]);
+
+    block.receipts[0].result.expectOk().expectBool(true);
+    // preorder 
+    block.receipts[1].result.expectOk().expectUint(149);
+    // try to register for wrong user
+    block.receipts[2].result.expectErr().expectUint(404);
+    // register for provided user
+    block.receipts[3].result.expectOk().expectBool(true);
+
+    // fees are sent to controller-admin and escrow on preorder
+    block.receipts[1].events.expectSTXTransferEvent(
+      6999999,
+      account1,
+      deployer
+    );
+    block.receipts[1].events.expectSTXTransferEvent(
+      3000000,
+      account1,
+      `${deployer}.ryder-handles-controller`
+    );
+
+    // fees in escrow are sent to community treasury on register
+    block.receipts[3].events.expectSTXTransferEvent(
+      3000000,
+      `${deployer}.ryder-handles-controller`,
+      deployer
+    );
   },
 });
 
@@ -131,16 +244,7 @@ Clarinet.test({
 
     setupNamespace(chain, deployer);
 
-    let block = chain.mineBlock([
-      Tx.contractCall(
-        "community-handles",
-        "set-namespace-controller",
-        ["0x67676767676767676767", `'${deployer}.ryder-handles-controller`],
-        deployer
-      ),
-    ]);
-
-    block.receipts[0].result.expectOk().expectBool(true);
+    setupNamespaceController(chain, deployer);
 
     const hashResponse1 = chain.callReadOnlyFn(
       "crypto",
@@ -149,7 +253,7 @@ Clarinet.test({
       deployer
     );
 
-    block = chain.mineBlock([
+    let block = chain.mineBlock([
       Tx.contractCall(
         "ryder-handles-controller",
         "set-approval-pubkey",
@@ -221,17 +325,7 @@ Clarinet.test({
     const account2 = accounts.get("wallet_2")!.address;
 
     setupNamespace(chain, deployer);
-
-    let block = chain.mineBlock([
-      Tx.contractCall(
-        "community-handles",
-        "set-namespace-controller",
-        ["0x67676767676767676767", `'${deployer}.ryder-handles-controller`],
-        deployer
-      ),
-    ]);
-
-    block.receipts[0].result.expectOk().expectBool(true);
+    setupNamespaceController(chain, deployer);
 
     const hashResponse1 = chain.callReadOnlyFn(
       "crypto",
@@ -240,7 +334,7 @@ Clarinet.test({
       deployer
     );
 
-    block = chain.mineBlock([
+    let block = chain.mineBlock([
       Tx.contractCall(
         "ryder-handles-controller",
         "set-approval-pubkey",
@@ -346,17 +440,7 @@ Clarinet.test({
     const account2 = accounts.get("wallet_2")!.address;
 
     setupNamespace(chain, deployer);
-
-    let block = chain.mineBlock([
-      Tx.contractCall(
-        "community-handles",
-        "set-namespace-controller",
-        ["0x67676767676767676767", `'${deployer}.ryder-handles-controller`],
-        deployer
-      ),
-    ]);
-
-    block.receipts[0].result.expectOk().expectBool(true);
+    setupNamespaceController(chain, deployer);
 
     const hashResponse1 = chain.callReadOnlyFn(
       "crypto",
@@ -365,7 +449,7 @@ Clarinet.test({
       deployer
     );
 
-    block = chain.mineBlock([
+    let block = chain.mineBlock([
       Tx.contractCall(
         "ryder-handles-controller",
         "set-approval-pubkey",
@@ -481,19 +565,9 @@ Clarinet.test({
     const account2 = accounts.get("wallet_2")!.address;
 
     setupNamespace2(chain, deployer);
+    setupNamespaceController2(chain, deployer);
 
     let block = chain.mineBlock([
-      Tx.contractCall(
-        "community-handles",
-        "set-namespace-controller",
-        ["0x68686868686868686868", `'${deployer}.ryder-handles-controller`],
-        deployer
-      ),
-    ]);
-
-    block.receipts[0].result.expectOk().expectBool(true);
-
-    block = chain.mineBlock([
       Tx.contractCall(
         "ryder-handles-controller",
         "set-namespace-controller",

--- a/backend-public/tests/utils.ts
+++ b/backend-public/tests/utils.ts
@@ -4,7 +4,7 @@ export function setupNamespace(chain: Chain, deployer: string) {
   const hashResponse = chain.callReadOnlyFn(
     "crypto",
     "crypto-hash160",
-    ["0x6767676767676767676700"],
+    ["0x6767676767676767676700"], // namespace + salt 0x00
     deployer
   );
 

--- a/frontend-dev/src/components/preorder-name-button.tsx
+++ b/frontend-dev/src/components/preorder-name-button.tsx
@@ -1,4 +1,4 @@
-import { bufferCV, bufferCVFromString, ClarityValue, tupleCV } from 'micro-stacks/clarity';
+import { bufferCV, bufferCVFromString, ClarityValue, noneCV, tupleCV } from 'micro-stacks/clarity';
 import { useOpenContractCall } from '@micro-stacks/react';
 import {
   createAssetInfo,
@@ -32,7 +32,7 @@ export const PreorderNameButton = ({
   const contractAddress = contract.address;
   const contractName = contract.name;
   const functionName = 'name-preorder';
-  const functionArgs: ClarityValue[] = [bufferCV(hashedSaltedName)];
+  const functionArgs: ClarityValue[] = [bufferCV(hashedSaltedName), noneCV()];
 
   const postConditions: PostCondition[] = [
     makeStandardSTXPostCondition(stxAddress, FungibleConditionCode.LessEqual, 10_000_000),


### PR DESCRIPTION
This PR collects all changes for v2
* **Add optional buyer during preorder**. Users can now provide an address that should receive the name. In v1, this was always the tx-sender.
* **Prevent double redeem**. Now, fees from expired preorders can only claimed once. In v1, it was possible to claim the fees as often as you want. 